### PR TITLE
fix: wrap SCD2 updates in database transactions and deduplicate logic

### DIFF
--- a/src/lib/scd2.ts
+++ b/src/lib/scd2.ts
@@ -6,12 +6,17 @@ import { eq, and } from "drizzle-orm";
  * Updates a user profile using SCD2 pattern:
  * 1. Close the current row (set valid_to + is_current = false)
  * 2. Insert a new row with updated values (valid_from = now, is_current = true)
+ *
+ * Both operations are wrapped in a transaction to prevent data corruption
+ * if the process fails between step 1 and step 2.
  */
 export async function updateUserProfile(
   userId: string,
-  updates: { name?: string; email?: string }
+  updates: { name?: string; email?: string; emailVerified?: Date | null }
 ) {
-  // Get current version
+  // Read current version outside the transaction.
+  // The neon-http driver batches transaction queries, so we cannot
+  // use one query's result as input to another within the same transaction.
   const [current] = await db
     .select()
     .from(users)
@@ -24,24 +29,31 @@ export async function updateUserProfile(
 
   const now = new Date();
 
-  // Close current row
-  await db
-    .update(users)
-    .set({ validTo: now, isCurrent: false })
-    .where(eq(users.id, current.id));
+  // Wrap close + insert in a transaction for atomicity.
+  // If either operation fails, both are rolled back.
+  const [newVersion] = await db.transaction(async (tx) => {
+    // Close current row
+    await tx
+      .update(users)
+      .set({ validTo: now, isCurrent: false })
+      .where(eq(users.id, current.id));
 
-  // Insert new version
-  const [newVersion] = await db
-    .insert(users)
-    .values({
-      userId: current.userId,
-      email: updates.email ?? current.email,
-      name: updates.name ?? current.name,
-      emailVerified: current.emailVerified,
-      validFrom: now,
-      isCurrent: true,
-    })
-    .returning();
+    // Insert new version
+    return tx
+      .insert(users)
+      .values({
+        userId: current.userId,
+        email: updates.email ?? current.email,
+        name: updates.name ?? current.name,
+        emailVerified:
+          updates.emailVerified !== undefined
+            ? updates.emailVerified
+            : current.emailVerified,
+        validFrom: now,
+        isCurrent: true,
+      })
+      .returning();
+  });
 
   return newVersion;
 }


### PR DESCRIPTION
## Summary
- Wrap SCD2 UPDATE + INSERT in `db.transaction()` for atomicity in `src/lib/scd2.ts` — prevents data corruption if process crashes between the two operations
- Add `emailVerified?: Date | null` parameter to `updateUserProfile` to support NextAuth email verification flow
- Deduplicate `auth.ts` `updateUser` method by delegating to `updateUserProfile` instead of reimplementing SCD2 logic

## Plan
Implements Phase 01 from `documentation/planning/tech_debt/finance-app-v1_2026-02-12/01_db-transaction-safety.md`

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Sign in via email magic link — verification flow works
- [ ] `PUT /api/profile` with `{ "name": "New Name" }` — old row has `is_current = false`, new row has `is_current = true`
- [ ] `GET /api/profile/history` — both old and new rows appear
- [ ] Verify `tx.update()` and `tx.insert()` used inside transaction (not `db.`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)