### PR TITLE
security: add Telegram webhook auth and API input validation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,7 @@ PLAID_COUNTRY_CODES=US
 
 # Telegram
 TELEGRAM_BOT_TOKEN=your-telegram-bot-token
+TELEGRAM_WEBHOOK_SECRET=generate-a-random-secret-here
 
 # Encryption (32-byte hex string for AES-256)
 ENCRYPTION_KEY=generate-a-64-char-hex-string-here

--- a/src/app/api/analytics/income-vs-spending/route.ts
+++ b/src/app/api/analytics/income-vs-spending/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
+import { isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -13,6 +14,13 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
+
+  if (startDate && !isValidDateParam(startDate)) {
+    return NextResponse.json({ error: "Invalid startDate format. Use YYYY-MM-DD." }, { status: 400 });
+  }
+  if (endDate && !isValidDateParam(endDate)) {
+    return NextResponse.json({ error: "Invalid endDate format. Use YYYY-MM-DD." }, { status: 400 });
+  }
 
   const conditions = [eq(transactions.userId, session.user.id)];
 

--- a/src/app/api/analytics/spending-by-category/route.ts
+++ b/src/app/api/analytics/spending-by-category/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
+import { isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -13,6 +14,13 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
+
+  if (startDate && !isValidDateParam(startDate)) {
+    return NextResponse.json({ error: "Invalid startDate format. Use YYYY-MM-DD." }, { status: 400 });
+  }
+  if (endDate && !isValidDateParam(endDate)) {
+    return NextResponse.json({ error: "Invalid endDate format. Use YYYY-MM-DD." }, { status: 400 });
+  }
 
   const conditions = [
     eq(transactions.userId, session.user.id),

--- a/src/app/api/analytics/spending-by-merchant/route.ts
+++ b/src/app/api/analytics/spending-by-merchant/route.ts
@@ -3,6 +3,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
+import { clampInt, isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
   const session = await auth();
@@ -13,7 +14,14 @@ export async function GET(request: NextRequest) {
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");
   const endDate = searchParams.get("endDate");
-  const limit = parseInt(searchParams.get("limit") || "20");
+  const limit = clampInt(searchParams.get("limit"), 20, 1, 100);
+
+  if (startDate && !isValidDateParam(startDate)) {
+    return NextResponse.json({ error: "Invalid startDate format. Use YYYY-MM-DD." }, { status: 400 });
+  }
+  if (endDate && !isValidDateParam(endDate)) {
+    return NextResponse.json({ error: "Invalid endDate format. Use YYYY-MM-DD." }, { status: 400 });
+  }
 
   const conditions = [
     eq(transactions.userId, session.user.id),

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,41 @@
+import { timingSafeEqual } from "crypto";
+
+/**
+ * ISO date format regex: YYYY-MM-DD
+ */
+const ISO_DATE_REGEX = /^\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])$/;
+
+/**
+ * Validates that a string is in YYYY-MM-DD format.
+ */
+export function isValidDateParam(value: string): boolean {
+  return ISO_DATE_REGEX.test(value);
+}
+
+/**
+ * Clamps a numeric value between min and max (inclusive).
+ * If the parsed value is NaN, returns the defaultValue.
+ */
+export function clampInt(
+  raw: string | null,
+  defaultValue: number,
+  min: number,
+  max: number
+): number {
+  const parsed = parseInt(raw || String(defaultValue), 10);
+  if (isNaN(parsed)) return defaultValue;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+/**
+ * Timing-safe string comparison to prevent timing attacks.
+ */
+export function timingSafeCompare(a: string, b: string): boolean {
+  if (a.length !== b.length) {
+    // Still do a comparison to avoid early-exit timing leak
+    const buf = Buffer.from(a);
+    timingSafeEqual(buf, buf);
+    return false;
+  }
+  return timingSafeEqual(Buffer.from(a), Buffer.from(b));
+}


### PR DESCRIPTION
## Summary
- Create `src/lib/validation.ts` with `isValidDateParam`, `clampInt`, `timingSafeCompare` utilities
- Add webhook secret verification to Telegram route via `X-Telegram-Bot-Api-Secret-Token` header
- Clamp `limit`/`offset` on transactions route ([1,200] and [0,100000]) and merchant route ([1,100])
- Add YYYY-MM-DD date format validation to all 4 API routes (transactions, categories, merchants, income-vs-spending)
- Add `TELEGRAM_WEBHOOK_SECRET` to `.env.example`

## Plan
Implements Phase 03 from `documentation/planning/tech_debt/finance-app-v1_2026-02-12/03_security-hardening.md`

## Deployment notes
⚠️ `TELEGRAM_WEBHOOK_SECRET` env var **must be set before deploy**. Missing secret returns 500 (fail closed).
After deploy, re-register Telegram webhook with `secret_token` parameter.

## Test plan
- [ ] `npx tsc --noEmit` passes (verified)
- [ ] Missing env var → HTTP 500
- [ ] No header → HTTP 401
- [ ] Wrong header → HTTP 401
- [ ] Correct header + valid body → HTTP 200
- [ ] `?limit=999999` on transactions → clamped to 200
- [ ] `?startDate=not-a-date` → HTTP 400
- [ ] `?endDate=2024-13-01` → HTTP 400
- [ ] No date params → accepted (optional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)