### PR TITLE
feat: evolve schema for manual transaction import

### DIFF
--- a/src/app/api/cron/sync-transactions/route.ts
+++ b/src/app/api/cron/sync-transactions/route.ts
@@ -24,6 +24,9 @@ export async function GET(request: NextRequest) {
   >();
 
   for (const acct of allAccounts) {
+    // Skip non-Plaid accounts (manual/import accounts have no Plaid fields)
+    if (!acct.plaidItemId || !acct.plaidAccessToken || !acct.plaidAccountId) continue;
+
     if (!itemMap.has(acct.plaidItemId)) {
       itemMap.set(acct.plaidItemId, {
         accessToken: decrypt(acct.plaidAccessToken),
@@ -76,6 +79,7 @@ export async function GET(request: NextRequest) {
                 categoryDetailed:
                   txn.personal_finance_category?.detailed ?? null,
                 pending: txn.pending,
+                source: "plaid" as const,
               };
             })
             .filter((v): v is NonNullable<typeof v> => v !== null);

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -58,6 +58,7 @@ export async function GET(request: NextRequest) {
       categoryPrimary: transactions.categoryPrimary,
       categoryDetailed: transactions.categoryDetailed,
       pending: transactions.pending,
+      source: transactions.source,
       accountName: accounts.name,
       accountType: accounts.type,
     })

--- a/src/components/transaction-table.tsx
+++ b/src/components/transaction-table.tsx
@@ -86,6 +86,11 @@ export function TransactionTable({
                 </td>
                 <td className="py-3 px-2 text-gray-500 text-xs">
                   {txn.accountName}
+                  {txn.source === "import" && (
+                    <span className="ml-1 px-1 py-0.5 bg-blue-50 text-blue-600 rounded text-[10px]">
+                      Import
+                    </span>
+                  )}
                 </td>
                 <td
                   className={`py-3 px-2 text-right font-medium whitespace-nowrap ${

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,19 +74,20 @@ export const verificationTokens = pgTable(
   }
 );
 
-// ─── Bank Accounts (via Plaid) ────────────────────────────────────────────────
+// ─── Bank Accounts ───────────────────────────────────────────────────────────
 export const accounts = pgTable(
   "accounts",
   {
     id: uuid("id").defaultRandom().primaryKey(),
     userId: uuid("user_id").notNull(),
-    plaidItemId: text("plaid_item_id").notNull(),
-    plaidAccessToken: text("plaid_access_token").notNull(),
-    plaidAccountId: text("plaid_account_id").notNull(),
+    plaidItemId: text("plaid_item_id"),
+    plaidAccessToken: text("plaid_access_token"),
+    plaidAccountId: text("plaid_account_id"),
     name: text("name").notNull(),
     type: text("type").notNull(),
     subtype: text("subtype"),
     mask: text("mask"),
+    source: text("source").notNull().default("plaid"),
     cursor: text("cursor"),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
@@ -103,7 +104,8 @@ export const transactions = pgTable(
     id: uuid("id").defaultRandom().primaryKey(),
     accountId: uuid("account_id").notNull(),
     userId: uuid("user_id").notNull(),
-    plaidTransactionId: text("plaid_transaction_id").notNull().unique(),
+    plaidTransactionId: text("plaid_transaction_id").unique(),
+    importId: text("import_id").unique(),
     amount: decimal("amount", { precision: 12, scale: 2 }).notNull(),
     date: date("date", { mode: "string" }).notNull(),
     name: text("name").notNull(),
@@ -111,6 +113,7 @@ export const transactions = pgTable(
     categoryPrimary: text("category_primary"),
     categoryDetailed: text("category_detailed"),
     pending: boolean("pending").notNull().default(false),
+    source: text("source").notNull().default("plaid"),
     createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -7,6 +7,7 @@ export interface Transaction {
   categoryPrimary: string | null;
   categoryDetailed: string | null;
   pending: boolean;
+  source: "plaid" | "import";
   accountName: string | null;
   accountType: string | null;
 }


### PR DESCRIPTION
## Summary
- Make `plaidTransactionId` nullable — imported transactions don't have Plaid IDs
- Add `importId` column with unique constraint for import dedup
- Add `source` column to both `transactions` and `accounts` tables (default: `"plaid"`)
- Make account Plaid fields (`plaidItemId`, `plaidAccessToken`, `plaidAccountId`) nullable for manual accounts
- Update transactions API to return `source` field
- Add subtle source badge to transaction table for imported transactions
- Update Plaid sync to explicitly set `source: "plaid"` and skip non-Plaid accounts

## Phase
Phase 01 of [Transaction Import feature](documentation/planning/phases/transaction-import_2026-02-17/01_schema-evolution.md)

## Verification
- All 34 existing tests pass
- TypeScript compiles clean
- `drizzle-kit push` confirms "No changes detected" (schema in sync)
- Database columns verified via direct SQL query

## Test plan
- [x] TypeScript compiles without errors
- [x] All existing tests pass (34/34)
- [x] Schema pushed to Neon — `drizzle-kit push` shows no pending changes
- [x] `source` column defaults to `"plaid"` for all existing rows
- [x] `plaid_transaction_id` is now nullable
- [x] `import_id` has unique constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)