### PR TITLE
feat: add manual account creation for imported transactions

### DIFF
--- a/documentation/planning/phases/transaction-import_2026-02-17/00_OVERVIEW.md
+++ b/documentation/planning/phases/transaction-import_2026-02-17/00_OVERVIEW.md
@@ -30,9 +30,9 @@ Plaid sandbox works but production approval is uncertain for a personal-use app.
 
 | # | Phase | PR Scope | Effort | Dependencies |
 |---|-------|----------|--------|-------------|
-| 01 | Schema Evolution | Add `source` column, make `plaidTransactionId` nullable, add manual accounts support | Low | None |
-| 02 | File Parsers | CSV + OFX parser library with format auto-detection | Medium | None | 🔧 IN PROGRESS |
-| 03 | Manual Accounts | API + UI for creating non-Plaid accounts | Low | Phase 01 |
+| 01 | Schema Evolution | Add `source` column, make `plaidTransactionId` nullable, add manual accounts support | Low | None | ✅ PR #7 |
+| 02 | File Parsers | CSV + OFX parser library with format auto-detection | Medium | None | ✅ PR #8 |
+| 03 | Manual Accounts | API + UI for creating non-Plaid accounts | Low | Phase 01 | ✅ PR #9 |
 | 04 | Import API + Dedup | Upload endpoint, preview, duplicate detection, confirm+insert | Medium | Phases 01, 02, 03 |
 | 05 | Import UI | Drag-and-drop upload component, preview table, dedup confirmation | Medium | Phase 04 |
 

--- a/documentation/planning/phases/transaction-import_2026-02-17/03_manual-accounts.md
+++ b/documentation/planning/phases/transaction-import_2026-02-17/03_manual-accounts.md
@@ -1,8 +1,8 @@
 # Phase 03: Manual Accounts
 
 **PR Title:** feat: add manual account creation for imported transactions
-**Risk:** Low | **Effort:** Low | **Status:** 🔧 IN PROGRESS
-**Started:** 2026-02-17
+**Risk:** Low | **Effort:** Low | **Status:** ✅ COMPLETE
+**Started:** 2026-02-17 | **Completed:** 2026-02-17 | **PR:** #9
 
 ## Context
 

--- a/documentation/planning/phases/transaction-import_2026-02-17/03_manual-accounts.md
+++ b/documentation/planning/phases/transaction-import_2026-02-17/03_manual-accounts.md
@@ -1,0 +1,169 @@
+# Phase 03: Manual Accounts
+
+**PR Title:** feat: add manual account creation for imported transactions
+**Risk:** Low | **Effort:** Low | **Status:** 🔧 IN PROGRESS
+**Started:** 2026-02-17
+
+## Context
+
+Imported transactions need an account to belong to. Currently, accounts can only be created through Plaid Link. This phase adds a simple API + UI for creating manual accounts (e.g., "Amex Platinum", "BofA Checking") that imported transactions will be assigned to.
+
+## Dependencies
+
+- **Blocks:** Phase 04 (import API)
+- **Blocked by:** Phase 01 (schema — needs nullable Plaid fields + account source column)
+
+## Files Created
+
+- `src/app/api/accounts/route.ts` — GET (list) + POST (create) manual accounts
+- (none — validation added to existing `src/lib/validation.ts`)
+- `src/app/dashboard/import/page.tsx` — Minimal placeholder page (full UI in Phase 05)
+
+## Files Modified
+
+- `src/app/dashboard/layout.tsx` — add "Import" nav link with `Upload` icon to sidebar
+
+## Detailed Implementation
+
+### 1. Accounts API route (`src/app/api/accounts/route.ts`)
+
+```typescript
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { accounts } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+// GET /api/accounts — list user's accounts
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userAccounts = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      type: accounts.type,
+      subtype: accounts.subtype,
+      mask: accounts.mask,
+      source: accounts.source,
+    })
+    .from(accounts)
+    .where(eq(accounts.userId, session.user.id));
+
+  return NextResponse.json({ accounts: userAccounts });
+}
+
+// POST /api/accounts — create manual account
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { name, type, subtype, mask } = await request.json();
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return NextResponse.json({ error: "Account name is required" }, { status: 400 });
+  }
+  if (!type || typeof type !== "string") {
+    return NextResponse.json({ error: "Account type is required" }, { status: 400 });
+  }
+
+  const validTypes = ["checking", "savings", "credit", "investment", "other"];
+  if (!validTypes.includes(type)) {
+    return NextResponse.json(
+      { error: `Invalid type. Must be one of: ${validTypes.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  const [created] = await db
+    .insert(accounts)
+    .values({
+      userId: session.user.id,
+      name: name.trim(),
+      type,
+      subtype: subtype?.trim() || null,
+      mask: mask?.trim() || null,
+      source: "import",
+      // Plaid fields left null for manual accounts
+    })
+    .returning();
+
+  return NextResponse.json({
+    account: {
+      id: created.id,
+      name: created.name,
+      type: created.type,
+      subtype: created.subtype,
+      mask: created.mask,
+      source: created.source,
+    },
+  });
+}
+```
+
+### 2. Extract account validation (`src/lib/validation/accounts.ts`)
+
+Pure function for validating account creation input — testable without mocking Next.js or auth:
+
+```typescript
+export const VALID_ACCOUNT_TYPES = ["checking", "savings", "credit", "investment", "other"] as const;
+export type AccountType = (typeof VALID_ACCOUNT_TYPES)[number];
+
+export function validateAccountInput(input: unknown): { name: string; type: AccountType; subtype: string | null; mask: string | null } | { error: string } { ... }
+```
+
+Route handler calls this and returns 400 if error, proceeds if valid.
+
+### 3. Add "Import" to sidebar navigation
+
+In `src/app/dashboard/layout.tsx`, add `Upload` icon import and nav item (after Merchants):
+
+```typescript
+import { Upload } from "lucide-react";
+// ...
+{ href: "/dashboard/import", label: "Import", icon: Upload },
+```
+
+### 4. Placeholder import page (`src/app/dashboard/import/page.tsx`)
+
+Minimal page so the nav link doesn't 404. Just a heading — Phase 05 replaces this entirely.
+
+### 3. Protect the import route in middleware
+
+The existing middleware matcher already covers `/dashboard/:path*`, so `/dashboard/import` is automatically protected. No changes needed.
+
+## Test Plan
+
+1. **API test (manual):**
+   - POST `/api/accounts` with `{ name: "Amex Platinum", type: "credit" }` → 201 with account object
+   - POST `/api/accounts` with `{ name: "" }` → 400 error
+   - POST `/api/accounts` with `{ name: "Test", type: "invalid" }` → 400 error
+   - GET `/api/accounts` → returns both Plaid and manual accounts
+   - Unauthenticated request → 401
+
+2. **Unit test** (`src/__tests__/accounts.test.ts`):
+   - Test `validateAccountInput` pure function:
+     - Valid input returns parsed result
+     - Empty/missing name returns error
+     - Missing type returns error
+     - Invalid type returns error
+     - Trims name/subtype/mask whitespace
+     - Null for empty optional fields
+
+## Verification Checklist
+
+- [ ] POST creates account with `source: "import"` and null Plaid fields
+- [ ] GET returns all accounts (both Plaid and manual)
+- [ ] Sidebar shows "Import" link
+- [ ] No existing Plaid functionality broken
+
+## What NOT To Do
+
+- Don't add account editing or deletion — out of scope for this feature
+- Don't add an account creation modal/page yet — Phase 05 (Import UI) will inline it into the import flow
+- Don't modify the Plaid exchange-token route — it stays as-is with its own account creation

--- a/src/__tests__/accounts.test.ts
+++ b/src/__tests__/accounts.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  validateAccountInput,
+  VALID_ACCOUNT_TYPES,
+} from "@/lib/validation";
+
+describe("validateAccountInput", () => {
+  it("accepts valid input with all fields", () => {
+    const result = validateAccountInput({
+      name: "Amex Platinum",
+      type: "credit",
+      subtype: "charge card",
+      mask: "1234",
+    });
+    expect(result).toEqual({
+      name: "Amex Platinum",
+      type: "credit",
+      subtype: "charge card",
+      mask: "1234",
+    });
+  });
+
+  it("accepts valid input with only required fields", () => {
+    const result = validateAccountInput({
+      name: "Checking",
+      type: "checking",
+    });
+    expect(result).toEqual({
+      name: "Checking",
+      type: "checking",
+      subtype: null,
+      mask: null,
+    });
+  });
+
+  it("trims whitespace from name", () => {
+    const result = validateAccountInput({
+      name: "  My Account  ",
+      type: "savings",
+    });
+    expect("name" in result && result.name).toBe("My Account");
+  });
+
+  it("trims whitespace from subtype and mask", () => {
+    const result = validateAccountInput({
+      name: "Test",
+      type: "credit",
+      subtype: "  visa  ",
+      mask: "  5678  ",
+    });
+    expect(result).toEqual({
+      name: "Test",
+      type: "credit",
+      subtype: "visa",
+      mask: "5678",
+    });
+  });
+
+  it("returns null for empty optional string fields", () => {
+    const result = validateAccountInput({
+      name: "Test",
+      type: "checking",
+      subtype: "",
+      mask: "   ",
+    });
+    expect(result).toEqual({
+      name: "Test",
+      type: "checking",
+      subtype: null,
+      mask: null,
+    });
+  });
+
+  it("rejects empty name", () => {
+    const result = validateAccountInput({ name: "", type: "credit" });
+    expect(result).toEqual({ error: "Account name is required" });
+  });
+
+  it("rejects whitespace-only name", () => {
+    const result = validateAccountInput({ name: "   ", type: "credit" });
+    expect(result).toEqual({ error: "Account name is required" });
+  });
+
+  it("rejects missing name", () => {
+    const result = validateAccountInput({ type: "credit" });
+    expect(result).toEqual({ error: "Account name is required" });
+  });
+
+  it("rejects missing type", () => {
+    const result = validateAccountInput({ name: "Test" });
+    expect(result).toEqual({ error: "Account type is required" });
+  });
+
+  it("rejects invalid type", () => {
+    const result = validateAccountInput({ name: "Test", type: "invalid" });
+    expect(result).toEqual({
+      error: `Invalid type. Must be one of: ${VALID_ACCOUNT_TYPES.join(", ")}`,
+    });
+  });
+
+  it("rejects null input", () => {
+    const result = validateAccountInput(null);
+    expect(result).toEqual({ error: "Request body is required" });
+  });
+
+  it("accepts all valid account types", () => {
+    for (const type of VALID_ACCOUNT_TYPES) {
+      const result = validateAccountInput({ name: "Test", type });
+      expect("name" in result).toBe(true);
+    }
+  });
+});

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { accounts } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { validateAccountInput } from "@/lib/validation";
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userAccounts = await db
+    .select({
+      id: accounts.id,
+      name: accounts.name,
+      type: accounts.type,
+      subtype: accounts.subtype,
+      mask: accounts.mask,
+      source: accounts.source,
+    })
+    .from(accounts)
+    .where(eq(accounts.userId, session.user.id));
+
+  return NextResponse.json({ accounts: userAccounts });
+}
+
+export async function POST(request: NextRequest) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await request.json();
+  const result = validateAccountInput(body);
+
+  if ("error" in result) {
+    return NextResponse.json({ error: result.error }, { status: 400 });
+  }
+
+  const [created] = await db
+    .insert(accounts)
+    .values({
+      userId: session.user.id,
+      name: result.name,
+      type: result.type,
+      subtype: result.subtype,
+      mask: result.mask,
+      source: "import",
+    })
+    .returning();
+
+  return NextResponse.json({
+    account: {
+      id: created.id,
+      name: created.name,
+      type: created.type,
+      subtype: created.subtype,
+      mask: created.mask,
+      source: created.source,
+    },
+  });
+}

--- a/src/app/dashboard/import/page.tsx
+++ b/src/app/dashboard/import/page.tsx
@@ -1,0 +1,10 @@
+export default function ImportPage() {
+  return (
+    <div>
+      <h1 className="text-2xl font-bold text-gray-900">Import Transactions</h1>
+      <p className="mt-2 text-gray-600">
+        Upload bank export files (CSV, QFX, QBO) to import transactions.
+      </p>
+    </div>
+  );
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import {
   Receipt,
   PieChart,
   Store,
+  Upload,
   User,
   LogOut,
 } from "lucide-react";
@@ -18,6 +19,7 @@ const navItems = [
   { href: "/dashboard/transactions", label: "Transactions", icon: Receipt },
   { href: "/dashboard/categories", label: "Categories", icon: PieChart },
   { href: "/dashboard/merchants", label: "Merchants", icon: Store },
+  { href: "/dashboard/import", label: "Import", icon: Upload },
 ];
 
 export default function DashboardLayout({

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -28,6 +28,65 @@ export function clampInt(
 }
 
 /**
+ * Valid account types for manual account creation.
+ */
+export const VALID_ACCOUNT_TYPES = [
+  "checking",
+  "savings",
+  "credit",
+  "investment",
+  "other",
+] as const;
+
+export type AccountType = (typeof VALID_ACCOUNT_TYPES)[number];
+
+interface AccountInputValid {
+  name: string;
+  type: AccountType;
+  subtype: string | null;
+  mask: string | null;
+}
+
+interface AccountInputError {
+  error: string;
+}
+
+/**
+ * Validates and normalizes account creation input.
+ * Returns parsed fields on success, or an error message on failure.
+ */
+export function validateAccountInput(
+  input: unknown
+): AccountInputValid | AccountInputError {
+  if (!input || typeof input !== "object") {
+    return { error: "Request body is required" };
+  }
+
+  const { name, type, subtype, mask } = input as Record<string, unknown>;
+
+  if (!name || typeof name !== "string" || name.trim().length === 0) {
+    return { error: "Account name is required" };
+  }
+
+  if (!type || typeof type !== "string") {
+    return { error: "Account type is required" };
+  }
+
+  if (!VALID_ACCOUNT_TYPES.includes(type as AccountType)) {
+    return {
+      error: `Invalid type. Must be one of: ${VALID_ACCOUNT_TYPES.join(", ")}`,
+    };
+  }
+
+  return {
+    name: name.trim(),
+    type: type as AccountType,
+    subtype: typeof subtype === "string" && subtype.trim() ? subtype.trim() : null,
+    mask: typeof mask === "string" && mask.trim() ? mask.trim() : null,
+  };
+}
+
+/**
  * Timing-safe string comparison to prevent timing attacks.
  */
 export function timingSafeCompare(a: string, b: string): boolean {


### PR DESCRIPTION
## Summary
- Add `validateAccountInput()` pure validation function to `src/lib/validation.ts` with type-safe account types
- Create `GET/POST /api/accounts` route for listing and creating manual accounts (source: "import")
- Add "Import" nav link with Upload icon to dashboard sidebar
- Add placeholder import page

## Verification
- 80 tests pass (12 new for account validation)
- TypeScript clean
- All valid account types accepted: checking, savings, credit, investment, other
- Empty/missing name, missing type, invalid type all return 400

## Test plan
- [x] `validateAccountInput` — 12 unit tests covering valid input, trimming, empty optionals, all error cases
- [x] TypeScript compilation passes
- [x] Nav link renders with correct icon

Phase 03 of [transaction-import plan](documentation/planning/phases/transaction-import_2026-02-17/03_manual-accounts.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)