### PR TITLE
feat: dark-themed Recharts with styled tooltips and dark grids

### DIFF
--- a/src/components/category-chart.tsx
+++ b/src/components/category-chart.tsx
@@ -6,25 +6,66 @@ import {
   Cell,
   ResponsiveContainer,
   Tooltip,
-  Legend,
 } from "recharts";
 import { formatCurrency } from "@/lib/utils";
 import type { CategoryData } from "@/types";
 
 const COLORS = [
-  "#3b82f6",
-  "#ef4444",
-  "#22c55e",
-  "#f59e0b",
-  "#8b5cf6",
-  "#ec4899",
-  "#14b8a6",
-  "#f97316",
-  "#6366f1",
-  "#84cc16",
-  "#06b6d4",
-  "#e11d48",
+  "#3b82f6", // blue-500
+  "#ef4444", // red-500
+  "#22c55e", // green-500
+  "#f59e0b", // amber-500
+  "#8b5cf6", // violet-500
+  "#ec4899", // pink-500
+  "#14b8a6", // teal-500
+  "#f97316", // orange-500
+  "#a78bfa", // violet-400 (avoids indigo accent collision)
+  "#a3e635", // lime-400 (brighter on dark)
+  "#06b6d4", // cyan-500
+  "#e11d48", // rose-600
 ];
+
+const CHART_THEME = {
+  tooltip: {
+    contentStyle: {
+      backgroundColor: "rgba(19, 17, 28, 0.9)",
+      border: "1px solid rgba(255, 255, 255, 0.1)",
+      borderRadius: "12px",
+      backdropFilter: "blur(12px)",
+    },
+    labelStyle: { color: "#ffffff", fontWeight: 600 },
+    itemStyle: { color: "#a1a1aa" },
+  },
+} as const;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function renderPieLabel(props: any) {
+  const cx = Number(props.cx ?? 0);
+  const cy = Number(props.cy ?? 0);
+  const midAngle = Number(props.midAngle ?? 0);
+  const innerRadius = Number(props.innerRadius ?? 0);
+  const outerRadius = Number(props.outerRadius ?? 0);
+  const name = String(props.name ?? "");
+  const percent = Number(props.percent ?? 0);
+
+  const RADIAN = Math.PI / 180;
+  const radius = innerRadius + (outerRadius - innerRadius) * 1.4;
+  const x = cx + radius * Math.cos(-midAngle * RADIAN);
+  const y = cy + radius * Math.sin(-midAngle * RADIAN);
+
+  return (
+    <text
+      x={x}
+      y={y}
+      fill="#a1a1aa"
+      textAnchor={x > cx ? "start" : "end"}
+      dominantBaseline="central"
+      fontSize={12}
+    >
+      {`${name} ${(percent * 100).toFixed(0)}%`}
+    </text>
+  );
+}
 
 export function CategoryChart({ data }: { data: CategoryData[] }) {
   if (data.length === 0) {
@@ -48,10 +89,8 @@ export function CategoryChart({ data }: { data: CategoryData[] }) {
               innerRadius={60}
               dataKey="total"
               nameKey="category"
-              label={(props) =>
-                `${props.name ?? ""} ${((props.percent ?? 0) * 100).toFixed(0)}%`
-              }
-              labelLine={true}
+              label={renderPieLabel}
+              labelLine={{ stroke: "#71717a" }}
             >
               {data.map((_, index) => (
                 <Cell
@@ -62,6 +101,9 @@ export function CategoryChart({ data }: { data: CategoryData[] }) {
             </Pie>
             <Tooltip
               formatter={(value) => formatCurrency(Number(value ?? 0))}
+              contentStyle={CHART_THEME.tooltip.contentStyle}
+              labelStyle={CHART_THEME.tooltip.labelStyle}
+              itemStyle={CHART_THEME.tooltip.itemStyle}
             />
           </PieChart>
         </ResponsiveContainer>

--- a/src/components/income-spending-chart.tsx
+++ b/src/components/income-spending-chart.tsx
@@ -20,6 +20,27 @@ interface MonthlyData {
   net: number;
 }
 
+const CHART_THEME = {
+  grid: { stroke: "rgba(255, 255, 255, 0.06)" },
+  axis: {
+    tick: { fill: "#a1a1aa" },
+    axisLine: { stroke: "rgba(255, 255, 255, 0.08)" },
+    tickLine: { stroke: "rgba(255, 255, 255, 0.08)" },
+  },
+  tooltip: {
+    contentStyle: {
+      backgroundColor: "rgba(19, 17, 28, 0.9)",
+      border: "1px solid rgba(255, 255, 255, 0.1)",
+      borderRadius: "12px",
+      backdropFilter: "blur(12px)",
+    },
+    labelStyle: { color: "#ffffff", fontWeight: 600 },
+    itemStyle: { color: "#a1a1aa" },
+  },
+  referenceLine: { stroke: "rgba(255, 255, 255, 0.15)" },
+  legend: { wrapperStyle: { color: "#a1a1aa" } },
+} as const;
+
 export function IncomeSpendingChart({ data }: { data: MonthlyData[] }) {
   if (data.length === 0) {
     return (
@@ -32,15 +53,35 @@ export function IncomeSpendingChart({ data }: { data: MonthlyData[] }) {
   return (
     <ResponsiveContainer width="100%" height={400}>
       <BarChart data={data} margin={{ top: 20, right: 30, left: 20, bottom: 5 }}>
-        <CartesianGrid strokeDasharray="3 3" />
-        <XAxis dataKey="month" />
-        <YAxis tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`} />
+        <CartesianGrid
+          strokeDasharray="3 3"
+          stroke={CHART_THEME.grid.stroke}
+        />
+        <XAxis
+          dataKey="month"
+          tick={CHART_THEME.axis.tick}
+          axisLine={CHART_THEME.axis.axisLine}
+          tickLine={CHART_THEME.axis.tickLine}
+        />
+        <YAxis
+          tickFormatter={(v) => `$${(v / 1000).toFixed(0)}k`}
+          tick={CHART_THEME.axis.tick}
+          axisLine={CHART_THEME.axis.axisLine}
+          tickLine={CHART_THEME.axis.tickLine}
+        />
         <Tooltip
           formatter={(value) => formatCurrency(Number(value ?? 0))}
-          labelStyle={{ fontWeight: "bold" }}
+          contentStyle={CHART_THEME.tooltip.contentStyle}
+          labelStyle={CHART_THEME.tooltip.labelStyle}
+          itemStyle={CHART_THEME.tooltip.itemStyle}
+          cursor={{ fill: "rgba(255, 255, 255, 0.04)" }}
         />
-        <Legend />
-        <ReferenceLine y={0} stroke="#000" />
+        <Legend wrapperStyle={CHART_THEME.legend.wrapperStyle} />
+        <ReferenceLine
+          y={0}
+          stroke={CHART_THEME.referenceLine.stroke}
+          strokeDasharray="3 3"
+        />
         <Bar dataKey="income" fill="#22c55e" name="Income" radius={[4, 4, 0, 0]} />
         <Bar dataKey="spending" fill="#ef4444" name="Spending" radius={[4, 4, 0, 0]} />
       </BarChart>

--- a/src/components/merchant-chart.tsx
+++ b/src/components/merchant-chart.tsx
@@ -12,6 +12,25 @@ import {
 import { formatCurrency } from "@/lib/utils";
 import type { MerchantData } from "@/types";
 
+const CHART_THEME = {
+  grid: { stroke: "rgba(255, 255, 255, 0.06)" },
+  axis: {
+    tick: { fill: "#a1a1aa" },
+    axisLine: { stroke: "rgba(255, 255, 255, 0.08)" },
+    tickLine: { stroke: "rgba(255, 255, 255, 0.08)" },
+  },
+  tooltip: {
+    contentStyle: {
+      backgroundColor: "rgba(19, 17, 28, 0.9)",
+      border: "1px solid rgba(255, 255, 255, 0.1)",
+      borderRadius: "12px",
+      backdropFilter: "blur(12px)",
+    },
+    labelStyle: { color: "#ffffff", fontWeight: 600 },
+    itemStyle: { color: "#a1a1aa" },
+  },
+} as const;
+
 export function MerchantChart({ data }: { data: MerchantData[] }) {
   if (data.length === 0) {
     return (
@@ -29,14 +48,33 @@ export function MerchantChart({ data }: { data: MerchantData[] }) {
           layout="vertical"
           margin={{ top: 5, right: 30, left: 100, bottom: 5 }}
         >
-          <CartesianGrid strokeDasharray="3 3" />
+          <CartesianGrid
+            strokeDasharray="3 3"
+            stroke={CHART_THEME.grid.stroke}
+          />
           <XAxis
             type="number"
             tickFormatter={(v) => `$${v.toLocaleString()}`}
+            tick={CHART_THEME.axis.tick}
+            axisLine={CHART_THEME.axis.axisLine}
+            tickLine={CHART_THEME.axis.tickLine}
           />
-          <YAxis type="category" dataKey="merchant" width={90} tick={{ fontSize: 12 }} />
-          <Tooltip formatter={(value) => formatCurrency(Number(value ?? 0))} />
-          <Bar dataKey="total" fill="#3b82f6" radius={[0, 4, 4, 0]} />
+          <YAxis
+            type="category"
+            dataKey="merchant"
+            width={90}
+            tick={{ fontSize: 12, fill: "#a1a1aa" }}
+            axisLine={CHART_THEME.axis.axisLine}
+            tickLine={CHART_THEME.axis.tickLine}
+          />
+          <Tooltip
+            formatter={(value) => formatCurrency(Number(value ?? 0))}
+            contentStyle={CHART_THEME.tooltip.contentStyle}
+            labelStyle={CHART_THEME.tooltip.labelStyle}
+            itemStyle={CHART_THEME.tooltip.itemStyle}
+            cursor={{ fill: "rgba(255, 255, 255, 0.04)" }}
+          />
+          <Bar dataKey="total" fill="#6366f1" radius={[0, 4, 4, 0]} />
         </BarChart>
       </ResponsiveContainer>
 


### PR DESCRIPTION
## Summary
- Add `CHART_THEME` constants to all 3 chart components with dark grid, axis, tooltip, and legend styling
- Style `CartesianGrid`, `XAxis`, `YAxis` with muted tick/axis line colors for dark backgrounds
- Add glassmorphism-style tooltips (dark translucent bg with backdrop-blur, rounded corners)
- Fix `ReferenceLine` from invisible `#000` to themed rgba stroke with dashed style
- Add custom `renderPieLabel` function with `#a1a1aa` SVG fill for dark-visible pie labels
- Update `COLORS` array: replace indigo-500 (accent collision) with violet-400, replace lime-500 with lime-400
- Change merchant bar fill from `#3b82f6` (blue) to `#6366f1` (indigo accent)
- Preserve all existing design tokens (`text-foreground-muted`, `border-border`, `bg-accent/20`, etc.)

**Files changed:** `income-spending-chart.tsx`, `category-chart.tsx`, `merchant-chart.tsx`

## Test plan
- [x] Build passes (`npm run build`)
- [x] 100/100 tests pass (`npx vitest run`)
- [ ] Visual: grid lines are subtle on dark bg
- [ ] Visual: axis labels readable in muted zinc
- [ ] Visual: tooltips have glass effect (dark bg, blur, rounded)
- [ ] Visual: ReferenceLine visible as dashed line
- [ ] Visual: pie labels are muted zinc, not black
- [ ] Visual: merchant bars are indigo-500
- [ ] Visual: recurring badge uses dark-safe translucent indigo

🤖 Generated with [Claude Code](https://claude.com/claude-code)