### PR TITLE
feat: redesign import page with polished dropzone and preview

### DIFF
--- a/src/app/dashboard/import/page.tsx
+++ b/src/app/dashboard/import/page.tsx
@@ -144,7 +144,7 @@ export default function ImportPage() {
 
       {state === "preview" && (
         <div className="mb-4">
-          <label className="block text-sm font-medium text-foreground-muted mb-1">
+          <label className="block text-sm font-medium text-foreground-muted mb-2">
             Import to account:
           </label>
           <div className="flex gap-2">
@@ -159,7 +159,7 @@ export default function ImportPage() {
                   setSelectedAccountId(e.target.value);
                 }
               }}
-              className="flex-1 p-2 border border-border rounded-lg bg-background-elevated text-foreground"
+              className="flex-1 px-4 py-2.5 border border-border rounded-xl bg-background-elevated text-foreground focus:ring-2 focus:ring-accent focus:border-accent outline-none transition-all duration-150 appearance-none"
             >
               <option value="">Select account...</option>
               {accounts.map((a) => (
@@ -172,7 +172,7 @@ export default function ImportPage() {
           </div>
 
           {showNewAccount && (
-            <div className="mt-2 p-3 border border-border rounded-lg bg-background-elevated flex gap-2 items-end">
+            <div className="mt-3 p-4 border border-border rounded-xl bg-background-elevated/50 backdrop-blur-xl flex gap-3 items-end">
               <div className="flex-1">
                 <label className="block text-xs text-foreground-tertiary">Name</label>
                 <input
@@ -180,7 +180,7 @@ export default function ImportPage() {
                   value={newAccountName}
                   onChange={(e) => setNewAccountName(e.target.value)}
                   placeholder="e.g., Amex Platinum"
-                  className="w-full p-2 border border-border rounded bg-background text-foreground placeholder:text-foreground-tertiary"
+                  className="w-full px-3 py-2 border border-border rounded-xl bg-background text-foreground placeholder:text-foreground-tertiary focus:ring-2 focus:ring-accent focus:border-accent outline-none transition-all duration-150"
                 />
               </div>
               <div>
@@ -188,7 +188,7 @@ export default function ImportPage() {
                 <select
                   value={newAccountType}
                   onChange={(e) => setNewAccountType(e.target.value)}
-                  className="p-2 border border-border rounded bg-background-elevated text-foreground"
+                  className="px-3 py-2 border border-border rounded-xl bg-background text-foreground focus:ring-2 focus:ring-accent focus:border-accent outline-none transition-all duration-150"
                 >
                   <option value="credit">Credit Card</option>
                   <option value="checking">Checking</option>
@@ -200,8 +200,7 @@ export default function ImportPage() {
               <button
                 onClick={handleCreateAccount}
                 disabled={!newAccountName.trim()}
-                className="px-4 py-2 bg-accent text-foreground rounded
-                           disabled:opacity-50 transition-all duration-150 active:scale-95"
+                className="px-4 py-2 bg-accent text-foreground rounded-xl hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-all duration-150 active:scale-95"
               >
                 Create
               </button>

--- a/src/components/file-dropzone.tsx
+++ b/src/components/file-dropzone.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { useState, useCallback } from "react";
+import { Upload } from "lucide-react";
 
 interface FileDropzoneProps {
   onFileSelect: (file: File) => void;
   loading?: boolean;
   acceptedFormats?: string;
 }
+
+const FORMAT_BADGES = ["CSV", "QFX", "QBO", "OFX"];
 
 export function FileDropzone({
   onFileSelect,
@@ -51,12 +54,12 @@ export function FileDropzone({
       onDragOver={handleDrag}
       onDrop={handleDrop}
       className={`
-        border-2 border-dashed rounded-2xl p-12 text-center cursor-pointer
-        transition-all duration-200
+        bg-background-card backdrop-blur-xl rounded-2xl border-2 border-dashed
+        p-8 sm:p-12 text-center cursor-pointer transition-all duration-200
         ${
           dragActive
-            ? "border-accent bg-accent/10 scale-[1.01]"
-            : "border-border bg-background-card hover:border-border-emphasis"
+            ? "border-accent bg-accent/10 scale-[1.01] animate-glow"
+            : "border-border hover:border-border-emphasis hover:bg-white/[0.03]"
         }
         ${loading ? "opacity-50 pointer-events-none" : ""}
       `}
@@ -70,12 +73,31 @@ export function FileDropzone({
         disabled={loading}
       />
       <label htmlFor="file-upload" className="cursor-pointer">
-        <p className="text-lg font-medium text-foreground-muted">
-          {loading ? "Parsing file..." : "Drop a bank export file here"}
-        </p>
-        <p className="text-sm text-foreground-tertiary mt-2">
-          or click to browse. Supports CSV, QFX, QBO, OFX
-        </p>
+        <div className="flex flex-col items-center gap-4">
+          <div className={`w-16 h-16 rounded-2xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center ${loading ? "animate-shimmer shimmer-bg" : ""}`}>
+            <Upload className="w-8 h-8 text-indigo-400" />
+          </div>
+
+          <div>
+            <p className="text-lg font-medium text-foreground">
+              {loading ? "Parsing file..." : "Drop your bank export here"}
+            </p>
+            <p className="text-sm text-foreground-muted mt-1">
+              or click to browse your files
+            </p>
+          </div>
+
+          <div className="flex gap-2 mt-2">
+            {FORMAT_BADGES.map((fmt) => (
+              <span
+                key={fmt}
+                className="px-2.5 py-1 text-xs font-medium rounded-full bg-white/[0.06] border border-white/[0.08] text-foreground-muted"
+              >
+                {fmt}
+              </span>
+            ))}
+          </div>
+        </div>
       </label>
     </div>
   );

--- a/src/components/import-preview.tsx
+++ b/src/components/import-preview.tsx
@@ -88,14 +88,13 @@ export function ImportPreview({
         <div className="flex gap-2">
           <button
             onClick={() => toggleAll(true)}
-            className="text-sm text-accent hover:text-accent-hover"
+            className="text-xs font-medium px-3 py-1 rounded-full bg-accent/10 text-accent hover:bg-accent/20 transition-all duration-150"
           >
             Select all
           </button>
-          <span className="text-foreground-tertiary">|</span>
           <button
             onClick={() => toggleAll(false)}
-            className="text-sm text-accent hover:text-accent-hover"
+            className="text-xs font-medium px-3 py-1 rounded-full bg-white/[0.06] text-foreground-muted hover:bg-white/[0.10] transition-all duration-150"
           >
             Deselect all
           </button>
@@ -105,7 +104,7 @@ export function ImportPreview({
       <div className="overflow-x-auto max-h-96 overflow-y-auto">
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-background-elevated">
-            <tr className="text-left text-foreground-tertiary">
+            <tr className="text-left text-foreground-tertiary text-xs uppercase tracking-wider">
               <th className="p-2 w-8"></th>
               <th className="p-2">Date</th>
               <th className="p-2">Description</th>
@@ -122,19 +121,20 @@ export function ImportPreview({
               return (
                 <tr
                   key={i}
-                  className={
+                  className={`transition-colors hover:bg-white/[0.03] ${
                     dup?.reason === "exact_import_id"
                       ? "bg-danger/10"
                       : dup
                         ? "bg-warning/10"
                         : ""
-                  }
+                  }`}
                 >
                   <td className="p-2">
                     <input
                       type="checkbox"
                       checked={selected.has(i)}
                       onChange={() => toggle(i)}
+                      className="w-4 h-4 rounded border-border bg-background-elevated text-accent focus:ring-accent focus:ring-offset-0 cursor-pointer accent-accent"
                     />
                   </td>
                   <td className="p-2 whitespace-nowrap">
@@ -175,8 +175,8 @@ export function ImportPreview({
         <button
           onClick={() => onConfirm(Array.from(selected))}
           disabled={selected.size === 0 || loading}
-          className="px-6 py-2 bg-accent text-foreground rounded-lg
-                     hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed"
+          className="px-6 py-2.5 bg-accent text-foreground rounded-xl font-medium
+                     hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
         >
           {loading
             ? "Importing..."


### PR DESCRIPTION
## Summary
- Rewrite `FileDropzone` with Upload icon, format badges (CSV/QFX/QBO/OFX), frosted glass card, drag glow animation, responsive padding
- Polish account selector with `rounded-xl`, focus rings, backdrop blur on create-account form
- Upgrade import preview: uppercase tracking headers, row hover states, styled checkboxes, pill-shaped select/deselect buttons, press animation on import button

Phase 02 of branding-polish session (`documentation/planning/phases/branding-polish_2026-03-02/02_import-page-ux.md`).

## Verification
- [x] TypeScript: zero errors
- [x] Tests: 100 passed (7 files)
- [x] All changes are purely visual — no logic, API, or data flow changes

## Test plan
- [ ] Navigate to Import page — dropzone shows Upload icon with frosted glass card
- [ ] Drag a file — border changes to accent, card glows
- [ ] Drop a file — preview appears with polished table
- [ ] Tab through account selector and checkboxes — focus rings visible
- [ ] Click Import — button shows press animation
- [ ] Select all / Deselect all display as pill buttons (no pipe separator)

🤖 Generated with [Claude Code](https://claude.com/claude-code)