### PR TITLE
Replace purple theme with clean minimal white design

### DIFF
--- a/src/app/auth/error/page.tsx
+++ b/src/app/auth/error/page.tsx
@@ -20,14 +20,13 @@ function ErrorContent() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(99,102,241,0.15),transparent_70%)]" />
-      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth backdrop-blur-2xl rounded-2xl border border-border shadow-2xl relative text-center animate-scale-in">
+      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth rounded-2xl border border-border shadow-sm relative text-center animate-scale-in">
         <AlertTriangle className="w-12 h-12 text-red-400 mx-auto mb-4" />
         <h1 className="text-2xl font-bold mb-2 text-danger">Authentication Error</h1>
         <p className="text-foreground-muted mb-6">{message}</p>
         <Link
           href="/auth/signin"
-          className="inline-block py-2 px-6 bg-accent text-foreground rounded-xl hover:bg-accent-hover font-medium transition-all duration-150 active:scale-95"
+          className="inline-block py-2 px-6 bg-accent text-white rounded-xl hover:bg-accent-hover font-medium transition-all duration-150 active:scale-95"
         >
           Try again
         </Link>
@@ -41,8 +40,7 @@ export default function AuthErrorPage() {
     <Suspense
       fallback={
         <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden">
-          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(99,102,241,0.15),transparent_70%)]" />
-          <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth backdrop-blur-2xl rounded-2xl border border-border shadow-2xl relative text-center">
+          <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth rounded-2xl border border-border shadow-sm relative text-center">
             <p className="text-foreground-muted">Loading...</p>
           </div>
         </div>

--- a/src/app/auth/signin/page.tsx
+++ b/src/app/auth/signin/page.tsx
@@ -22,8 +22,7 @@ export default function SignInPage() {
   if (sent) {
     return (
       <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden">
-        <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(99,102,241,0.20),transparent_60%)]" />
-
+  
         <Link
           href="/"
           className="absolute top-6 left-6 flex items-center gap-1.5 text-sm text-foreground-muted hover:text-foreground transition-colors duration-150"
@@ -32,9 +31,9 @@ export default function SignInPage() {
           Home
         </Link>
 
-        <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth backdrop-blur-2xl rounded-2xl border border-border shadow-2xl relative animate-scale-in">
+        <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth rounded-2xl border border-border shadow-sm relative animate-scale-in">
           <div className="text-center">
-            <Mail className="w-12 h-12 text-indigo-400 mx-auto mb-4" />
+            <Mail className="w-12 h-12 text-foreground-muted mx-auto mb-4" />
             <h1 className="text-2xl font-bold mb-2">Check your email</h1>
             <p className="text-foreground-muted">
               We sent a sign-in link to <strong className="text-foreground">{email}</strong>. Click the link
@@ -48,8 +47,6 @@ export default function SignInPage() {
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(99,102,241,0.20),transparent_60%)]" />
-
       {/* Back link */}
       <Link
         href="/"
@@ -59,14 +56,10 @@ export default function SignInPage() {
         Home
       </Link>
 
-      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth backdrop-blur-2xl rounded-2xl border border-border shadow-2xl relative animate-scale-in">
+      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth rounded-2xl border border-border shadow-sm relative animate-scale-in">
         <div className="text-center mb-8">
           <h1 className="text-2xl font-bold">
-            Really{" "}
-            <span className="bg-gradient-to-r from-indigo-400 to-violet-400 bg-clip-text text-transparent">
-              Personal
-            </span>{" "}
-            Finance
+            Really Personal Finance
           </h1>
           <p className="text-foreground-muted mt-2">
             Track your spending, your way.
@@ -77,7 +70,7 @@ export default function SignInPage() {
           type="button"
           onClick={() => { setGoogleLoading(true); signIn("google", { callbackUrl: "/dashboard" }); }}
           disabled={googleLoading || emailLoading}
-          className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-border rounded-xl bg-background hover:bg-white/5 text-foreground font-medium transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+          className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-border rounded-xl bg-background hover:bg-black/[0.03] text-foreground font-medium transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           <svg className="w-5 h-5" viewBox="0 0 24 24">
             <path
@@ -128,7 +121,7 @@ export default function SignInPage() {
           <button
             type="submit"
             disabled={emailLoading || googleLoading}
-            className="w-full py-2 px-4 bg-accent text-foreground rounded-xl hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-all duration-150 active:scale-95"
+            className="w-full py-2 px-4 bg-accent text-white rounded-xl hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-all duration-150 active:scale-95"
           >
             {emailLoading ? "Sending link..." : "Continue with email"}
           </button>

--- a/src/app/auth/verify/page.tsx
+++ b/src/app/auth/verify/page.tsx
@@ -3,9 +3,8 @@ import { Mail } from "lucide-react";
 export default function VerifyPage() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden">
-      <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(99,102,241,0.15),transparent_70%)]" />
-      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth backdrop-blur-2xl rounded-2xl border border-border shadow-2xl relative text-center animate-scale-in">
-        <Mail className="w-12 h-12 text-indigo-400 mx-auto mb-4" />
+      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth rounded-2xl border border-border shadow-sm relative text-center animate-scale-in">
+        <Mail className="w-12 h-12 text-foreground-muted mx-auto mb-4" />
         <h1 className="text-2xl font-bold mb-2">Check your email</h1>
         <p className="text-foreground-muted">
           A sign-in link has been sent to your email address. Click the link to

--- a/src/app/dashboard/categories/page.tsx
+++ b/src/app/dashboard/categories/page.tsx
@@ -58,7 +58,7 @@ export default function CategoriesPage() {
       />
 
       {/* Chart */}
-      <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-fade-in transition-all duration-200 hover:bg-white/8 hover:border-white/15" style={{ animationDelay: "100ms" }}>
+      <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-fade-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis" style={{ animationDelay: "100ms" }}>
         {loading ? (
           <div className="h-80 flex items-center justify-center text-foreground-tertiary">
             Loading...

--- a/src/app/dashboard/import/page.tsx
+++ b/src/app/dashboard/import/page.tsx
@@ -433,7 +433,7 @@ export default function ImportPage() {
               <button
                 onClick={handleCreateAccount}
                 disabled={!newAccountName.trim()}
-                className="px-4 py-2 bg-accent text-foreground rounded-xl hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-all duration-150 active:scale-95"
+                className="px-4 py-2 bg-accent text-white rounded-xl hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-all duration-150 active:scale-95"
               >
                 Create
               </button>
@@ -460,13 +460,13 @@ export default function ImportPage() {
           <div className="mt-4 flex gap-3 justify-center">
             <button
               onClick={resetAll}
-              className="px-4 py-2 bg-background-elevated border border-border rounded-lg hover:bg-white/5 transition-all duration-150 active:scale-95"
+              className="px-4 py-2 bg-background-elevated border border-border rounded-lg hover:bg-black/[0.04] transition-all duration-150 active:scale-95"
             >
               Import more
             </button>
             <a
               href="/dashboard/transactions"
-              className="px-4 py-2 bg-accent text-foreground rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95"
+              className="px-4 py-2 bg-accent text-white rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95"
             >
               View transactions
             </a>

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -118,7 +118,7 @@ export default function DashboardLayout({
             showLabels ? "px-3 py-2" : "justify-center px-0 py-2",
             active
               ? "bg-accent/10 text-accent"
-              : "text-foreground-muted hover:bg-white/5 hover:text-foreground"
+              : "text-foreground-muted hover:bg-black/[0.04] hover:text-foreground"
           )}
         >
           <item.icon className="w-5 h-5 shrink-0" />
@@ -137,7 +137,7 @@ export default function DashboardLayout({
             !showLabels ? (session?.user?.email || "Profile") : undefined
           }
           className={cn(
-            "flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-white/5 hover:text-foreground transition-colors",
+            "flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-black/[0.04] hover:text-foreground transition-colors",
             showLabels ? "px-3 py-2" : "justify-center px-0 py-2"
           )}
         >
@@ -152,7 +152,7 @@ export default function DashboardLayout({
           onClick={() => signOut({ callbackUrl: "/" })}
           title={!showLabels ? "Sign out" : undefined}
           className={cn(
-            "flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-white/5 hover:text-danger w-full transition-colors",
+            "flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-black/[0.04] hover:text-danger w-full transition-colors",
             showLabels ? "px-3 py-2" : "justify-center px-0 py-2"
           )}
         >
@@ -273,7 +273,7 @@ export default function DashboardLayout({
                   "px-0 group-hover/sidebar:px-3",
                   active
                     ? "bg-accent/10 text-accent"
-                    : "text-foreground-muted hover:bg-white/5 hover:text-foreground"
+                    : "text-foreground-muted hover:bg-black/[0.04] hover:text-foreground"
                 )}
               >
                 <item.icon className="w-5 h-5 shrink-0" />
@@ -290,7 +290,7 @@ export default function DashboardLayout({
           <Link
             href="/profile"
             title={session?.user?.email || "Profile"}
-            className="flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-white/5 hover:text-foreground transition-colors py-2 justify-center group-hover/sidebar:justify-start px-0 group-hover/sidebar:px-3"
+            className="flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-black/[0.04] hover:text-foreground transition-colors py-2 justify-center group-hover/sidebar:justify-start px-0 group-hover/sidebar:px-3"
           >
             <User className="w-5 h-5 shrink-0" />
             <span className="hidden group-hover/sidebar:inline truncate whitespace-nowrap">
@@ -300,7 +300,7 @@ export default function DashboardLayout({
           <button
             onClick={() => signOut({ callbackUrl: "/" })}
             title="Sign out"
-            className="flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-white/5 hover:text-danger w-full transition-colors py-2 justify-center group-hover/sidebar:justify-start px-0 group-hover/sidebar:px-3"
+            className="flex items-center gap-3 rounded-lg text-sm font-medium text-foreground-muted hover:bg-black/[0.04] hover:text-danger w-full transition-colors py-2 justify-center group-hover/sidebar:justify-start px-0 group-hover/sidebar:px-3"
           >
             <LogOut className="w-5 h-5 shrink-0" />
             <span className="hidden group-hover/sidebar:inline whitespace-nowrap">

--- a/src/app/dashboard/merchants/page.tsx
+++ b/src/app/dashboard/merchants/page.tsx
@@ -59,7 +59,7 @@ export default function MerchantsPage() {
       />
 
       {/* Chart + Table */}
-      <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-fade-in transition-all duration-200 hover:bg-white/8 hover:border-white/15" style={{ animationDelay: "100ms" }}>
+      <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-fade-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis" style={{ animationDelay: "100ms" }}>
         {loading ? (
           <div className="h-80 flex items-center justify-center text-foreground-tertiary">
             Loading...

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -53,19 +53,19 @@ export default function DashboardPage() {
 
       {/* Summary Cards */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "50ms" }}>
+        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "50ms" }}>
           <p className="text-sm text-foreground-muted">This Month Income</p>
           <p className="text-2xl font-bold text-income">
             {latestMonth ? formatCurrency(latestMonth.income) : "$0.00"}
           </p>
         </div>
-        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "125ms" }}>
+        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "125ms" }}>
           <p className="text-sm text-foreground-muted">This Month Spending</p>
           <p className="text-2xl font-bold text-spending">
             {latestMonth ? formatCurrency(latestMonth.spending) : "$0.00"}
           </p>
         </div>
-        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "200ms" }}>
+        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "200ms" }}>
           <p className="text-sm text-foreground-muted">This Month Net</p>
           <p
             className={`text-2xl font-bold ${
@@ -75,7 +75,7 @@ export default function DashboardPage() {
             {latestMonth ? formatCurrency(latestMonth.net) : "$0.00"}
           </p>
         </div>
-        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "275ms" }}>
+        <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-scale-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "275ms" }}>
           <p className="text-sm text-foreground-muted">All-Time Net</p>
           <p
             className={`text-2xl font-bold ${
@@ -88,7 +88,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Income vs Spending Chart */}
-      <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-fade-in transition-all duration-200 hover:bg-white/8 hover:border-white/15" style={{ animationDelay: "350ms" }}>
+      <div className="bg-background-card backdrop-blur-xl p-6 rounded-2xl border border-border animate-fade-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis" style={{ animationDelay: "350ms" }}>
         <h2 className="text-lg font-semibold mb-4">Income vs Spending</h2>
         {loading ? (
           <div className="h-96 flex items-center justify-center text-foreground-tertiary">

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -273,14 +273,14 @@ export default function SettingsPage() {
               <button
                 onClick={testTelegram}
                 disabled={telegramTesting || !telegramConfig.enabled}
-                className="flex items-center gap-2 px-3 py-2 text-sm font-medium bg-accent text-foreground rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="flex items-center gap-2 px-3 py-2 text-sm font-medium bg-accent text-white rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 <Send className="w-3.5 h-3.5" />
                 {telegramTesting ? "Sending..." : "Send Test Alert"}
               </button>
               <button
                 onClick={toggleTelegramEnabled}
-                className="px-3 py-2 text-sm font-medium border border-border text-foreground-muted rounded-lg hover:bg-white/5 transition-all duration-150 active:scale-95"
+                className="px-3 py-2 text-sm font-medium border border-border text-foreground-muted rounded-lg hover:bg-black/[0.04] transition-all duration-150 active:scale-95"
               >
                 {telegramConfig.enabled ? "Pause Alerts" : "Resume Alerts"}
               </button>
@@ -323,7 +323,7 @@ export default function SettingsPage() {
               <button
                 onClick={saveTelegramConfig}
                 disabled={!chatIdInput.trim() || telegramSaving}
-                className="px-4 py-2 text-sm font-medium bg-accent text-foreground rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
+                className="px-4 py-2 text-sm font-medium bg-accent text-white rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {telegramSaving ? "Saving..." : "Connect"}
               </button>
@@ -392,7 +392,7 @@ export default function SettingsPage() {
                       </button>
                       <button
                         onClick={() => setEditingAccountId(null)}
-                        className="p-1 text-foreground-muted hover:bg-white/5 rounded transition-colors"
+                        className="p-1 text-foreground-muted hover:bg-black/[0.04] rounded transition-colors"
                         title="Cancel"
                       >
                         <X className="w-4 h-4" />
@@ -433,7 +433,7 @@ export default function SettingsPage() {
                         setEditingAccountId(account.id);
                         setEditName(account.name);
                       }}
-                      className="p-1.5 text-foreground-muted hover:bg-white/5 rounded-lg transition-colors"
+                      className="p-1.5 text-foreground-muted hover:bg-black/[0.04] rounded-lg transition-colors"
                       title="Rename"
                     >
                       <Pencil className="w-4 h-4" />

--- a/src/app/dashboard/transactions/page.tsx
+++ b/src/app/dashboard/transactions/page.tsx
@@ -81,7 +81,7 @@ export default function TransactionsPage() {
         </div>
         <button
           onClick={() => setShowAddModal(true)}
-          className="flex items-center gap-2 px-4 py-2.5 bg-accent text-foreground rounded-xl font-medium hover:bg-accent-hover transition-all duration-150 active:scale-95"
+          className="flex items-center gap-2 px-4 py-2.5 bg-accent text-white rounded-xl font-medium hover:bg-accent-hover transition-all duration-150 active:scale-95"
         >
           <Plus className="w-4 h-4" />
           <span className="hidden sm:inline">Add Transaction</span>
@@ -105,8 +105,8 @@ export default function TransactionsPage() {
                 }}
                 className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-150 active:scale-95 ${
                   isActive
-                    ? "bg-accent text-foreground"
-                    : "border border-border text-foreground-muted hover:bg-white/5"
+                    ? "bg-accent text-white"
+                    : "border border-border text-foreground-muted hover:bg-black/[0.04]"
                 }`}
               >
                 {preset.label}
@@ -195,7 +195,7 @@ export default function TransactionsPage() {
           <button
             onClick={() => setOffset(Math.max(0, offset - limit))}
             disabled={offset === 0}
-            className="px-4 py-2 text-sm font-medium text-foreground-muted border border-border rounded-lg hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
+            className="px-4 py-2 text-sm font-medium text-foreground-muted border border-border rounded-lg hover:bg-black/[0.04] disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
           >
             Previous
           </button>
@@ -205,7 +205,7 @@ export default function TransactionsPage() {
           <button
             onClick={() => setOffset(offset + limit)}
             disabled={transactions.length < limit}
-            className="px-4 py-2 text-sm font-medium text-foreground-muted border border-border rounded-lg hover:bg-white/5 disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
+            className="px-4 py-2 text-sm font-medium text-foreground-muted border border-border rounded-lg hover:bg-black/[0.04] disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
           >
             Next
           </button>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -2,35 +2,35 @@
 
 :root {
   /* Backgrounds */
-  --background: #0c0a14;
-  --background-elevated: #13111c;
-  --background-card: rgba(255, 255, 255, 0.05);
-  --background-card-auth: rgba(255, 255, 255, 0.08);
+  --background: #ffffff;
+  --background-elevated: #f9fafb;
+  --background-card: rgba(0, 0, 0, 0.02);
+  --background-card-auth: rgba(0, 0, 0, 0.03);
 
   /* Foregrounds */
-  --foreground: #ffffff;
-  --foreground-muted: #a1a1aa;
-  --foreground-tertiary: #71717a;
+  --foreground: #111827;
+  --foreground-muted: #6b7280;
+  --foreground-tertiary: #9ca3af;
 
   /* Accent */
-  --accent: #6366f1;
-  --accent-hover: #818cf8;
-  --accent-pressed: #4f46e5;
+  --accent: #0f172a;
+  --accent-hover: #1e293b;
+  --accent-pressed: #020617;
 
   /* Semantic */
-  --success: #22c55e;
-  --danger: #ef4444;
-  --warning: #f59e0b;
+  --success: #16a34a;
+  --danger: #dc2626;
+  --warning: #d97706;
 
   /* Financial */
-  --income: #a78bfa;
-  --income-muted: rgba(167, 139, 250, 0.10);
-  --spending: #6366f1;
-  --spending-muted: rgba(99, 102, 241, 0.10);
+  --income: #059669;
+  --income-muted: rgba(5, 150, 105, 0.08);
+  --spending: #3b82f6;
+  --spending-muted: rgba(59, 130, 246, 0.08);
 
   /* Borders */
-  --border: rgba(255, 255, 255, 0.08);
-  --border-emphasis: rgba(255, 255, 255, 0.12);
+  --border: rgba(0, 0, 0, 0.08);
+  --border-emphasis: rgba(0, 0, 0, 0.15);
 }
 
 @theme inline {
@@ -74,7 +74,7 @@ body {
   background: var(--background);
   color: var(--foreground);
   font-family: var(--font-sans), system-ui, sans-serif;
-  color-scheme: dark;
+  color-scheme: light;
 }
 
 /* ============================================
@@ -126,10 +126,10 @@ body {
   @keyframes glow {
     0%,
     100% {
-      box-shadow: 0 0 8px rgba(99, 102, 241, 0.15);
+      box-shadow: 0 0 8px rgba(15, 23, 42, 0.08);
     }
     50% {
-      box-shadow: 0 0 20px rgba(99, 102, 241, 0.3);
+      box-shadow: 0 0 20px rgba(15, 23, 42, 0.15);
     }
   }
 }
@@ -138,9 +138,9 @@ body {
 @utility shimmer-bg {
   background: linear-gradient(
     90deg,
-    rgb(255 255 255 / 0.03) 25%,
-    rgb(255 255 255 / 0.08) 50%,
-    rgb(255 255 255 / 0.03) 75%
+    rgb(0 0 0 / 0.03) 25%,
+    rgb(0 0 0 / 0.06) 50%,
+    rgb(0 0 0 / 0.03) 75%
   );
   background-size: 200% 100%;
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -29,16 +29,10 @@ export default function Home() {
 
       {/* Hero */}
       <section className="relative max-w-6xl mx-auto px-4 sm:px-6 pt-24 sm:pt-32 pb-20 sm:pb-28">
-        {/* Decorative radial glow */}
-        <div
-          aria-hidden="true"
-          className="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[400px] sm:w-[800px] sm:h-[600px] bg-indigo-500/10 rounded-full blur-3xl pointer-events-none"
-        />
-
         <div className="relative text-center max-w-3xl mx-auto animate-fade-in-up">
           <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight leading-tight">
             Know where your{" "}
-            <span className="bg-gradient-to-r from-indigo-400 to-violet-400 bg-clip-text text-transparent">
+            <span className="text-foreground">
               money goes.
             </span>
           </h1>
@@ -49,7 +43,7 @@ export default function Home() {
           <div className="mt-10">
             <Link
               href="/auth/signin"
-              className="inline-flex items-center gap-2 px-8 py-3 bg-accent hover:bg-accent-hover text-foreground text-lg font-medium rounded-xl transition-all duration-150 active:scale-95"
+              className="inline-flex items-center gap-2 px-8 py-3 bg-accent hover:bg-accent-hover text-white text-lg font-medium rounded-xl transition-all duration-150 active:scale-95"
             >
               Get Started
               <ArrowRight className="w-5 h-5" />
@@ -61,9 +55,9 @@ export default function Home() {
       {/* Features */}
       <section className="max-w-6xl mx-auto px-4 sm:px-6 pb-20 sm:pb-28">
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-background-card backdrop-blur-xl border border-border rounded-2xl p-6 sm:p-8 animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "100ms" }}>
-            <div className="w-12 h-12 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mb-5">
-              <Landmark className="w-6 h-6 text-indigo-400" />
+          <div className="bg-background-card border border-border rounded-2xl p-6 sm:p-8 animate-scale-in transition-all duration-200 hover:bg-black/[0.03] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "100ms" }}>
+            <div className="w-12 h-12 rounded-xl bg-black/[0.04] border border-border flex items-center justify-center mb-5">
+              <Landmark className="w-6 h-6 text-foreground" />
             </div>
             <h3 className="text-lg font-semibold mb-2">Connect Your Banks</h3>
             <p className="text-sm text-foreground-muted leading-relaxed">
@@ -72,9 +66,9 @@ export default function Home() {
             </p>
           </div>
 
-          <div className="bg-background-card backdrop-blur-xl border border-border rounded-2xl p-6 sm:p-8 animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "175ms" }}>
-            <div className="w-12 h-12 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mb-5">
-              <TrendingUp className="w-6 h-6 text-indigo-400" />
+          <div className="bg-background-card border border-border rounded-2xl p-6 sm:p-8 animate-scale-in transition-all duration-200 hover:bg-black/[0.03] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "175ms" }}>
+            <div className="w-12 h-12 rounded-xl bg-black/[0.04] border border-border flex items-center justify-center mb-5">
+              <TrendingUp className="w-6 h-6 text-foreground" />
             </div>
             <h3 className="text-lg font-semibold mb-2">See the Big Picture</h3>
             <p className="text-sm text-foreground-muted leading-relaxed">
@@ -83,9 +77,9 @@ export default function Home() {
             </p>
           </div>
 
-          <div className="bg-background-card backdrop-blur-xl border border-border rounded-2xl p-6 sm:p-8 animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15 hover:-translate-y-0.5" style={{ animationDelay: "250ms" }}>
-            <div className="w-12 h-12 rounded-xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mb-5">
-              <Bell className="w-6 h-6 text-indigo-400" />
+          <div className="bg-background-card border border-border rounded-2xl p-6 sm:p-8 animate-scale-in transition-all duration-200 hover:bg-black/[0.03] hover:border-border-emphasis hover:-translate-y-0.5" style={{ animationDelay: "250ms" }}>
+            <div className="w-12 h-12 rounded-xl bg-black/[0.04] border border-border flex items-center justify-center mb-5">
+              <Bell className="w-6 h-6 text-foreground" />
             </div>
             <h3 className="text-lg font-semibold mb-2">Telegram Alerts</h3>
             <p className="text-sm text-foreground-muted leading-relaxed">
@@ -101,7 +95,7 @@ export default function Home() {
         <div className="text-center mb-12 animate-fade-in" style={{ animationDelay: "300ms" }}>
           <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
             Everything in{" "}
-            <span className="bg-gradient-to-r from-indigo-400 to-violet-400 bg-clip-text text-transparent">
+            <span className="text-foreground">
               one place
             </span>
           </h2>
@@ -111,21 +105,17 @@ export default function Home() {
         </div>
 
         <div className="relative animate-fade-in" style={{ animationDelay: "400ms" }}>
-          {/* Decorative glow behind the preview */}
-          <div
-            aria-hidden="true"
-            className="absolute inset-0 bg-indigo-500/8 rounded-3xl blur-2xl -m-4 pointer-events-none"
-          />
+          {/* Subtle shadow behind the preview */}
           <div className="relative bg-background-elevated border border-border rounded-2xl overflow-hidden shadow-2xl">
             {/* Mock browser chrome */}
             <div className="flex items-center gap-2 px-4 py-3 border-b border-border bg-background">
               <div className="flex gap-1.5">
-                <div className="w-3 h-3 rounded-full bg-white/10" />
-                <div className="w-3 h-3 rounded-full bg-white/10" />
-                <div className="w-3 h-3 rounded-full bg-white/10" />
+                <div className="w-3 h-3 rounded-full bg-black/10" />
+                <div className="w-3 h-3 rounded-full bg-black/10" />
+                <div className="w-3 h-3 rounded-full bg-black/10" />
               </div>
               <div className="flex-1 mx-8">
-                <div className="h-6 rounded-md bg-white/[0.06] max-w-xs mx-auto" />
+                <div className="h-6 rounded-md bg-black/[0.04] max-w-xs mx-auto" />
               </div>
             </div>
             {/* Mock dashboard content */}
@@ -133,15 +123,15 @@ export default function Home() {
               <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
                 <div className="bg-background-card rounded-xl p-4 border border-border">
                   <p className="text-xs text-foreground-tertiary">Income</p>
-                  <p className="text-lg font-bold text-violet-400 mt-1">$4,250</p>
+                  <p className="text-lg font-bold text-income mt-1">$4,250</p>
                 </div>
                 <div className="bg-background-card rounded-xl p-4 border border-border">
                   <p className="text-xs text-foreground-tertiary">Spending</p>
-                  <p className="text-lg font-bold text-indigo-400 mt-1">$2,847</p>
+                  <p className="text-lg font-bold text-spending mt-1">$2,847</p>
                 </div>
                 <div className="bg-background-card rounded-xl p-4 border border-border">
                   <p className="text-xs text-foreground-tertiary">Net</p>
-                  <p className="text-lg font-bold text-violet-400 mt-1">+$1,403</p>
+                  <p className="text-lg font-bold text-income mt-1">+$1,403</p>
                 </div>
                 <div className="bg-background-card rounded-xl p-4 border border-border">
                   <p className="text-xs text-foreground-tertiary">Accounts</p>
@@ -153,11 +143,11 @@ export default function Home() {
                 {[40, 65, 45, 80, 55, 70, 90, 60, 75, 50, 85, 68].map((h, i) => (
                   <div key={i} className="flex-1 flex flex-col gap-1 items-stretch">
                     <div
-                      className="rounded-t bg-violet-400/60"
+                      className="rounded-t bg-income/60"
                       style={{ height: `${h * 0.6}%` }}
                     />
                     <div
-                      className="rounded-t bg-indigo-500/60"
+                      className="rounded-t bg-spending/60"
                       style={{ height: `${h * 0.4}%` }}
                     />
                   </div>
@@ -173,7 +163,7 @@ export default function Home() {
         <div className="text-center mb-12 animate-fade-in" style={{ animationDelay: "450ms" }}>
           <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
             Up and running in{" "}
-            <span className="bg-gradient-to-r from-indigo-400 to-violet-400 bg-clip-text text-transparent">
+            <span className="text-foreground">
               minutes
             </span>
           </h2>
@@ -181,8 +171,8 @@ export default function Home() {
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8 animate-fade-in" style={{ animationDelay: "500ms" }}>
           <div className="text-center">
-            <div className="w-10 h-10 rounded-full bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mx-auto mb-4">
-              <span className="text-sm font-bold text-indigo-400">1</span>
+            <div className="w-10 h-10 rounded-full bg-black/[0.04] border border-border flex items-center justify-center mx-auto mb-4">
+              <span className="text-sm font-bold text-foreground">1</span>
             </div>
             <h3 className="font-semibold mb-2">Connect or Upload</h3>
             <p className="text-sm text-foreground-muted leading-relaxed">
@@ -191,8 +181,8 @@ export default function Home() {
           </div>
 
           <div className="text-center">
-            <div className="w-10 h-10 rounded-full bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mx-auto mb-4">
-              <span className="text-sm font-bold text-indigo-400">2</span>
+            <div className="w-10 h-10 rounded-full bg-black/[0.04] border border-border flex items-center justify-center mx-auto mb-4">
+              <span className="text-sm font-bold text-foreground">2</span>
             </div>
             <h3 className="font-semibold mb-2">See Your Patterns</h3>
             <p className="text-sm text-foreground-muted leading-relaxed">
@@ -201,8 +191,8 @@ export default function Home() {
           </div>
 
           <div className="text-center">
-            <div className="w-10 h-10 rounded-full bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center mx-auto mb-4">
-              <span className="text-sm font-bold text-indigo-400">3</span>
+            <div className="w-10 h-10 rounded-full bg-black/[0.04] border border-border flex items-center justify-center mx-auto mb-4">
+              <span className="text-sm font-bold text-foreground">3</span>
             </div>
             <h3 className="font-semibold mb-2">Get Daily Insights</h3>
             <p className="text-sm text-foreground-muted leading-relaxed">
@@ -214,10 +204,10 @@ export default function Home() {
 
       {/* Trust Section */}
       <section className="max-w-6xl mx-auto px-4 sm:px-6 pb-20 sm:pb-28">
-        <div className="bg-background-card backdrop-blur-xl border border-border rounded-2xl p-6 sm:p-8 animate-fade-in" style={{ animationDelay: "400ms" }}>
+        <div className="bg-background-card border border-border rounded-2xl p-6 sm:p-8 animate-fade-in" style={{ animationDelay: "400ms" }}>
           <div className="flex flex-col sm:flex-row items-start sm:items-center gap-6 sm:gap-10">
             <div className="flex items-start gap-3">
-              <ShieldCheck className="w-5 h-5 text-indigo-400 mt-0.5 shrink-0" />
+              <ShieldCheck className="w-5 h-5 text-foreground mt-0.5 shrink-0" />
               <div>
                 <p className="text-sm font-medium">Encrypted at Rest</p>
                 <p className="text-xs text-foreground-muted mt-0.5">
@@ -226,7 +216,7 @@ export default function Home() {
               </div>
             </div>
             <div className="flex items-start gap-3">
-              <Lock className="w-5 h-5 text-indigo-400 mt-0.5 shrink-0" />
+              <Lock className="w-5 h-5 text-foreground mt-0.5 shrink-0" />
               <div>
                 <p className="text-sm font-medium">Your Data, Your Control</p>
                 <p className="text-xs text-foreground-muted mt-0.5">
@@ -235,7 +225,7 @@ export default function Home() {
               </div>
             </div>
             <div className="flex items-start gap-3">
-              <Code className="w-5 h-5 text-indigo-400 mt-0.5 shrink-0" />
+              <Code className="w-5 h-5 text-foreground mt-0.5 shrink-0" />
               <div>
                 <p className="text-sm font-medium">Open Source</p>
                 <p className="text-xs text-foreground-muted mt-0.5">
@@ -250,10 +240,6 @@ export default function Home() {
       {/* Bottom CTA */}
       <section className="max-w-6xl mx-auto px-4 sm:px-6 pb-20 sm:pb-28">
         <div className="relative text-center animate-fade-in" style={{ animationDelay: "600ms" }}>
-          <div
-            aria-hidden="true"
-            className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[400px] h-[200px] bg-indigo-500/10 rounded-full blur-3xl pointer-events-none"
-          />
           <div className="relative">
             <h2 className="text-2xl sm:text-3xl font-bold tracking-tight">
               Ready to take control?
@@ -264,7 +250,7 @@ export default function Home() {
             <div className="mt-8">
               <Link
                 href="/auth/signin"
-                className="inline-flex items-center gap-2 px-8 py-3 bg-accent hover:bg-accent-hover text-foreground text-lg font-medium rounded-xl transition-all duration-150 active:scale-95"
+                className="inline-flex items-center gap-2 px-8 py-3 bg-accent hover:bg-accent-hover text-white text-lg font-medium rounded-xl transition-all duration-150 active:scale-95"
               >
                 Get Started
                 <ArrowRight className="w-5 h-5" />

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -52,7 +52,7 @@ export default function ProfilePage() {
           </Link>
         </div>
 
-        <div className="bg-background-card backdrop-blur-xl rounded-2xl border border-border p-6 animate-scale-in transition-all duration-200 hover:bg-white/8 hover:border-white/15">
+        <div className="bg-background-card backdrop-blur-xl rounded-2xl border border-border p-6 animate-scale-in transition-all duration-200 hover:bg-black/[0.04] hover:border-border-emphasis">
           <form onSubmit={handleSubmit} className="space-y-4">
             <div>
               <label
@@ -103,7 +103,7 @@ export default function ProfilePage() {
             <button
               type="submit"
               disabled={saving}
-              className="py-2 px-6 bg-accent text-foreground rounded-lg hover:bg-accent-hover disabled:opacity-50 font-medium transition-all duration-150 active:scale-95"
+              className="py-2 px-6 bg-accent text-white rounded-lg hover:bg-accent-hover disabled:opacity-50 font-medium transition-all duration-150 active:scale-95"
             >
               {saving ? "Saving..." : "Save Changes"}
             </button>

--- a/src/components/add-transaction-modal.tsx
+++ b/src/components/add-transaction-modal.tsx
@@ -84,14 +84,14 @@ export function AddTransactionModal({ accounts, onClose, onSaved }: AddTransacti
         <>
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2.5 border border-border rounded-xl text-foreground-muted hover:bg-white/5 transition-all duration-150 active:scale-95 font-medium"
+            className="flex-1 px-4 py-2.5 border border-border rounded-xl text-foreground-muted hover:bg-black/[0.04] transition-all duration-150 active:scale-95 font-medium"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={saving || !description.trim() || !amount}
-            className="flex-1 px-4 py-2.5 bg-accent text-foreground rounded-xl font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
+            className="flex-1 px-4 py-2.5 bg-accent text-white rounded-xl font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
           >
             {saving ? "Adding..." : "Add Transaction"}
           </button>
@@ -106,8 +106,8 @@ export function AddTransactionModal({ accounts, onClose, onSaved }: AddTransacti
             onClick={() => setIsExpense(true)}
             className={`flex-1 py-2 text-sm font-medium transition-colors ${
               isExpense
-                ? "bg-accent text-foreground"
-                : "bg-background text-foreground-muted hover:bg-white/5"
+                ? "bg-accent text-white"
+                : "bg-background text-foreground-muted hover:bg-black/[0.04]"
             }`}
           >
             Expense
@@ -118,7 +118,7 @@ export function AddTransactionModal({ accounts, onClose, onSaved }: AddTransacti
             className={`flex-1 py-2 text-sm font-medium transition-colors ${
               !isExpense
                 ? "bg-success text-foreground"
-                : "bg-background text-foreground-muted hover:bg-white/5"
+                : "bg-background text-foreground-muted hover:bg-black/[0.04]"
             }`}
           >
             Income

--- a/src/components/category-chart.tsx
+++ b/src/components/category-chart.tsx
@@ -15,26 +15,26 @@ const COLORS = [
   "#ef4444", // red-500
   "#22c55e", // green-500
   "#f59e0b", // amber-500
-  "#8b5cf6", // violet-500
+  "#06b6d4", // cyan-500
   "#ec4899", // pink-500
   "#14b8a6", // teal-500
   "#f97316", // orange-500
-  "#a78bfa", // violet-400 (avoids indigo accent collision)
-  "#a3e635", // lime-400 (brighter on dark)
-  "#06b6d4", // cyan-500
+  "#64748b", // slate-500
+  "#84cc16", // lime-500
+  "#8b5cf6", // violet-500
   "#e11d48", // rose-600
 ];
 
 const CHART_THEME = {
   tooltip: {
     contentStyle: {
-      backgroundColor: "rgba(19, 17, 28, 0.9)",
-      border: "1px solid rgba(255, 255, 255, 0.1)",
+      backgroundColor: "#ffffff",
+      border: "1px solid rgba(0, 0, 0, 0.1)",
       borderRadius: "12px",
-      backdropFilter: "blur(12px)",
+      boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
     },
-    labelStyle: { color: "#ffffff", fontWeight: 600 },
-    itemStyle: { color: "#a1a1aa" },
+    labelStyle: { color: "#111827", fontWeight: 600 },
+    itemStyle: { color: "#6b7280" },
   },
 } as const;
 
@@ -57,7 +57,7 @@ function renderPieLabel(props: any) {
     <text
       x={x}
       y={y}
-      fill="#a1a1aa"
+      fill="#6b7280"
       textAnchor={x > cx ? "start" : "end"}
       dominantBaseline="central"
       fontSize={12}
@@ -90,7 +90,7 @@ export function CategoryChart({ data }: { data: CategoryData[] }) {
               dataKey="total"
               nameKey="category"
               label={renderPieLabel}
-              labelLine={{ stroke: "#71717a" }}
+              labelLine={{ stroke: "#9ca3af" }}
             >
               {data.map((_, index) => (
                 <Cell

--- a/src/components/column-mapper.tsx
+++ b/src/components/column-mapper.tsx
@@ -426,7 +426,7 @@ export function ColumnMapper({
         <button
           onClick={handleConfirm}
           disabled={!isComplete || loading}
-          className="px-6 py-2.5 bg-accent text-foreground rounded-xl font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
+          className="px-6 py-2.5 bg-accent text-white rounded-xl font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
         >
           {loading ? "Processing..." : "Continue to Preview"}
         </button>

--- a/src/components/date-range-filter.tsx
+++ b/src/components/date-range-filter.tsx
@@ -31,8 +31,8 @@ export function DateRangeFilter({
               }}
               className={`px-3 py-1.5 text-xs font-medium rounded-lg transition-all duration-150 active:scale-95 ${
                 isActive
-                  ? "bg-accent text-foreground"
-                  : "border border-border text-foreground-muted hover:bg-white/5"
+                  ? "bg-accent text-white"
+                  : "border border-border text-foreground-muted hover:bg-black/[0.04]"
               }`}
             >
               {preset.label}

--- a/src/components/edit-transaction-modal.tsx
+++ b/src/components/edit-transaction-modal.tsx
@@ -58,14 +58,14 @@ export function EditTransactionModal({
         <>
           <button
             onClick={onClose}
-            className="flex-1 px-4 py-2.5 border border-border rounded-xl text-foreground-muted hover:bg-white/5 transition-all duration-150 active:scale-95 font-medium"
+            className="flex-1 px-4 py-2.5 border border-border rounded-xl text-foreground-muted hover:bg-black/[0.04] transition-all duration-150 active:scale-95 font-medium"
           >
             Cancel
           </button>
           <button
             onClick={handleSave}
             disabled={saving}
-            className="flex-1 px-4 py-2.5 bg-accent text-foreground rounded-xl font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
+            className="flex-1 px-4 py-2.5 bg-accent text-white rounded-xl font-medium hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
           >
             {saving ? "Saving..." : "Save"}
           </button>

--- a/src/components/file-dropzone.tsx
+++ b/src/components/file-dropzone.tsx
@@ -59,7 +59,7 @@ export function FileDropzone({
         ${
           dragActive
             ? "border-accent bg-accent/10 scale-[1.01] animate-glow"
-            : "border-border hover:border-border-emphasis hover:bg-white/[0.03]"
+            : "border-border hover:border-border-emphasis hover:bg-black/[0.03]"
         }
         ${loading ? "opacity-50 pointer-events-none" : ""}
       `}
@@ -74,8 +74,8 @@ export function FileDropzone({
       />
       <label htmlFor="file-upload" className="cursor-pointer">
         <div className="flex flex-col items-center gap-4">
-          <div className={`w-16 h-16 rounded-2xl bg-indigo-500/10 border border-indigo-500/20 flex items-center justify-center ${loading ? "animate-shimmer shimmer-bg" : ""}`}>
-            <Upload className="w-8 h-8 text-indigo-400" />
+          <div className={`w-16 h-16 rounded-2xl bg-black/[0.04] border border-border flex items-center justify-center ${loading ? "animate-shimmer shimmer-bg" : ""}`}>
+            <Upload className="w-8 h-8 text-foreground-muted" />
           </div>
 
           <div>
@@ -91,7 +91,7 @@ export function FileDropzone({
             {FORMAT_BADGES.map((fmt) => (
               <span
                 key={fmt}
-                className="px-2.5 py-1 text-xs font-medium rounded-full bg-white/[0.06] border border-white/[0.08] text-foreground-muted"
+                className="px-2.5 py-1 text-xs font-medium rounded-full bg-black/[0.04] border border-border text-foreground-muted"
               >
                 {fmt}
               </span>

--- a/src/components/import-preview.tsx
+++ b/src/components/import-preview.tsx
@@ -94,7 +94,7 @@ export function ImportPreview({
           </button>
           <button
             onClick={() => toggleAll(false)}
-            className="text-xs font-medium px-3 py-1 rounded-full bg-white/[0.06] text-foreground-muted hover:bg-white/[0.10] transition-all duration-150"
+            className="text-xs font-medium px-3 py-1 rounded-full bg-black/[0.04] text-foreground-muted hover:bg-black/[0.08] transition-all duration-150"
           >
             Deselect all
           </button>
@@ -121,7 +121,7 @@ export function ImportPreview({
               return (
                 <tr
                   key={i}
-                  className={`transition-colors hover:bg-white/[0.03] ${
+                  className={`transition-colors hover:bg-black/[0.03] ${
                     dup?.reason === "exact_import_id"
                       ? "bg-danger/10"
                       : dup
@@ -175,7 +175,7 @@ export function ImportPreview({
         <button
           onClick={() => onConfirm(Array.from(selected))}
           disabled={selected.size === 0 || loading}
-          className="px-6 py-2.5 bg-accent text-foreground rounded-xl font-medium
+          className="px-6 py-2.5 bg-accent text-white rounded-xl font-medium
                      hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed transition-all duration-150 active:scale-95"
         >
           {loading

--- a/src/components/income-spending-chart.tsx
+++ b/src/components/income-spending-chart.tsx
@@ -21,24 +21,24 @@ interface MonthlyData {
 }
 
 const CHART_THEME = {
-  grid: { stroke: "rgba(255, 255, 255, 0.06)" },
+  grid: { stroke: "rgba(0, 0, 0, 0.06)" },
   axis: {
-    tick: { fill: "#a1a1aa" },
-    axisLine: { stroke: "rgba(255, 255, 255, 0.08)" },
-    tickLine: { stroke: "rgba(255, 255, 255, 0.08)" },
+    tick: { fill: "#6b7280" },
+    axisLine: { stroke: "rgba(0, 0, 0, 0.08)" },
+    tickLine: { stroke: "rgba(0, 0, 0, 0.08)" },
   },
   tooltip: {
     contentStyle: {
-      backgroundColor: "rgba(19, 17, 28, 0.9)",
-      border: "1px solid rgba(255, 255, 255, 0.1)",
+      backgroundColor: "#ffffff",
+      border: "1px solid rgba(0, 0, 0, 0.1)",
       borderRadius: "12px",
-      backdropFilter: "blur(12px)",
+      boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
     },
-    labelStyle: { color: "#ffffff", fontWeight: 600 },
-    itemStyle: { color: "#a1a1aa" },
+    labelStyle: { color: "#111827", fontWeight: 600 },
+    itemStyle: { color: "#6b7280" },
   },
-  referenceLine: { stroke: "rgba(255, 255, 255, 0.15)" },
-  legend: { wrapperStyle: { color: "#a1a1aa" } },
+  referenceLine: { stroke: "rgba(0, 0, 0, 0.12)" },
+  legend: { wrapperStyle: { color: "#6b7280" } },
 } as const;
 
 export function IncomeSpendingChart({ data }: { data: MonthlyData[] }) {
@@ -74,7 +74,7 @@ export function IncomeSpendingChart({ data }: { data: MonthlyData[] }) {
           contentStyle={CHART_THEME.tooltip.contentStyle}
           labelStyle={CHART_THEME.tooltip.labelStyle}
           itemStyle={CHART_THEME.tooltip.itemStyle}
-          cursor={{ fill: "rgba(255, 255, 255, 0.04)" }}
+          cursor={{ fill: "rgba(0, 0, 0, 0.04)" }}
         />
         <Legend wrapperStyle={CHART_THEME.legend.wrapperStyle} />
         <ReferenceLine
@@ -82,8 +82,8 @@ export function IncomeSpendingChart({ data }: { data: MonthlyData[] }) {
           stroke={CHART_THEME.referenceLine.stroke}
           strokeDasharray="3 3"
         />
-        <Bar dataKey="income" fill="#a78bfa" name="Income" radius={[4, 4, 0, 0]} />
-        <Bar dataKey="spending" fill="#6366f1" name="Spending" radius={[4, 4, 0, 0]} />
+        <Bar dataKey="income" fill="#059669" name="Income" radius={[4, 4, 0, 0]} />
+        <Bar dataKey="spending" fill="#3b82f6" name="Spending" radius={[4, 4, 0, 0]} />
       </BarChart>
     </ResponsiveContainer>
   );

--- a/src/components/merchant-chart.tsx
+++ b/src/components/merchant-chart.tsx
@@ -13,21 +13,21 @@ import { formatCurrency } from "@/lib/utils";
 import type { MerchantData } from "@/types";
 
 const CHART_THEME = {
-  grid: { stroke: "rgba(255, 255, 255, 0.06)" },
+  grid: { stroke: "rgba(0, 0, 0, 0.06)" },
   axis: {
-    tick: { fill: "#a1a1aa" },
-    axisLine: { stroke: "rgba(255, 255, 255, 0.08)" },
-    tickLine: { stroke: "rgba(255, 255, 255, 0.08)" },
+    tick: { fill: "#6b7280" },
+    axisLine: { stroke: "rgba(0, 0, 0, 0.08)" },
+    tickLine: { stroke: "rgba(0, 0, 0, 0.08)" },
   },
   tooltip: {
     contentStyle: {
-      backgroundColor: "rgba(19, 17, 28, 0.9)",
-      border: "1px solid rgba(255, 255, 255, 0.1)",
+      backgroundColor: "#ffffff",
+      border: "1px solid rgba(0, 0, 0, 0.1)",
       borderRadius: "12px",
-      backdropFilter: "blur(12px)",
+      boxShadow: "0 4px 12px rgba(0, 0, 0, 0.08)",
     },
-    labelStyle: { color: "#ffffff", fontWeight: 600 },
-    itemStyle: { color: "#a1a1aa" },
+    labelStyle: { color: "#111827", fontWeight: 600 },
+    itemStyle: { color: "#6b7280" },
   },
 } as const;
 
@@ -63,7 +63,7 @@ export function MerchantChart({ data }: { data: MerchantData[] }) {
             type="category"
             dataKey="merchant"
             width={90}
-            tick={{ fontSize: 12, fill: "#a1a1aa" }}
+            tick={{ fontSize: 12, fill: "#6b7280" }}
             axisLine={CHART_THEME.axis.axisLine}
             tickLine={CHART_THEME.axis.tickLine}
           />
@@ -72,9 +72,9 @@ export function MerchantChart({ data }: { data: MerchantData[] }) {
             contentStyle={CHART_THEME.tooltip.contentStyle}
             labelStyle={CHART_THEME.tooltip.labelStyle}
             itemStyle={CHART_THEME.tooltip.itemStyle}
-            cursor={{ fill: "rgba(255, 255, 255, 0.04)" }}
+            cursor={{ fill: "rgba(0, 0, 0, 0.04)" }}
           />
-          <Bar dataKey="total" fill="#6366f1" radius={[0, 4, 4, 0]} />
+          <Bar dataKey="total" fill="#3b82f6" radius={[0, 4, 4, 0]} />
         </BarChart>
       </ResponsiveContainer>
 

--- a/src/components/sync-status-banner.tsx
+++ b/src/components/sync-status-banner.tsx
@@ -99,7 +99,7 @@ export function SyncStatusBanner() {
       <button
         onClick={triggerSync}
         disabled={syncing}
-        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-border text-foreground-muted rounded-lg hover:bg-white/5 transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+        className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium border border-border text-foreground-muted rounded-lg hover:bg-black/[0.04] transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
       >
         <RefreshCw className={`w-3 h-3 ${syncing ? "animate-spin" : ""}`} />
         Sync Now

--- a/src/components/transaction-table.tsx
+++ b/src/components/transaction-table.tsx
@@ -63,7 +63,7 @@ export function TransactionTable({
             const amount = parseFloat(txn.amount);
             const isIncome = amount < 0;
             return (
-              <tr key={txn.id} className="border-b border-border hover:bg-white/5 transition-colors duration-150">
+              <tr key={txn.id} className="border-b border-border hover:bg-black/[0.04] transition-colors duration-150">
                 <td className="py-3 px-2 text-foreground-muted whitespace-nowrap">
                   {formatDate(txn.date)}
                 </td>
@@ -90,8 +90,8 @@ export function TransactionTable({
                   <span
                     className={`inline-block px-2 py-0.5 text-xs rounded-full ${
                       txn.categoryPrimary
-                        ? "bg-white/10 text-foreground-muted"
-                        : "bg-white/5 text-foreground-tertiary border border-dashed border-border"
+                        ? "bg-black/10 text-foreground-muted"
+                        : "bg-black/[0.04] text-foreground-tertiary border border-dashed border-border"
                     } ${onEditTransaction ? "cursor-pointer hover:bg-accent/20 hover:text-accent group/cat transition-colors" : ""}`}
                     onClick={() => onEditTransaction?.(txn)}
                   >


### PR DESCRIPTION
## Summary

- **Replaces the dark purple/indigo theme** with a clean, minimal white design system — purple gradients were reading as "AI-generated"
- **New palette**: white backgrounds, slate-900 accent (near-black buttons), emerald for income, blue for spending
- **Updated 24 files** across CSS tokens, all 3 chart components, auth pages, landing page, dashboard, sidebar, modals, and every interactive component

## What changed

| Token | Before | After |
|-------|--------|-------|
| Background | `#0c0a14` (near-black) | `#ffffff` (white) |
| Accent | `#6366f1` (indigo-500) | `#0f172a` (slate-900) |
| Income | `#a78bfa` (violet-400) | `#059669` (emerald-600) |
| Spending | `#6366f1` (indigo-500) | `#3b82f6` (blue-500) |
| Borders | `rgba(255,255,255,0.08)` | `rgba(0,0,0,0.08)` |

- Removed all purple gradient text (`from-indigo-400 to-violet-400`)
- Removed radial indigo glows from auth pages
- Flipped all hover/card states from `white/` opacity to `black/` opacity
- Updated all chart tooltip and axis themes for light backgrounds
- Button text switched from `text-foreground` to `text-white` on dark accent

## Test plan

- [ ] Verify landing page renders clean white with no purple remnants
- [ ] Check sign-in, verify, and error auth pages for correct styling
- [ ] Confirm dashboard cards, charts, and sidebar look correct on white
- [ ] Test income (emerald) and spending (blue) colors in charts
- [ ] Verify button contrast — dark accent buttons should have white text
- [ ] Check mobile drawer and tablet sidebar hover states

https://claude.ai/code/session_012poZR1ADdd1HpSbF1Kc47j