### PR TITLE
fix(auth): remove dangerous email linking + add MFA rate limiting

### DIFF
--- a/src/app/api/mfa/verify/route.ts
+++ b/src/app/api/mfa/verify/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { confirmMfaEnrollment, verifyMfaCode, hasMfaEnabled } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
+import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
   const session = await auth();
@@ -16,22 +17,40 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid code" }, { status: 400 });
   }
 
+  const rateLimitKey = `mfa:${session.user.id}`;
+  const limit = checkRateLimit(rateLimitKey);
+  if (!limit.allowed) {
+    await audit({
+      userId: session.user.id,
+      action: "auth.mfa_rate_limited",
+      resource: "mfa",
+      detail: { retryAfterMs: limit.retryAfterMs },
+      request,
+    });
+    return NextResponse.json(
+      { error: "Too many attempts. Try again later." },
+      { status: 429 },
+    );
+  }
+
   const isEnrolled = await hasMfaEnabled(session.user.id);
 
   if (!isEnrolled) {
     // First-time verification during enrollment
     const success = await confirmMfaEnrollment(session.user.id, code);
     if (!success) {
+      const { remaining } = recordFailure(rateLimitKey);
       await audit({
         userId: session.user.id,
         action: "auth.mfa_failed",
         resource: "mfa",
-        detail: { phase: "enrollment" },
+        detail: { phase: "enrollment", attemptsRemaining: remaining },
         request,
       });
       return NextResponse.json({ error: "Invalid code" }, { status: 400 });
     }
 
+    resetAttempts(rateLimitKey);
     await audit({
       userId: session.user.id,
       action: "auth.mfa_verified",
@@ -46,16 +65,18 @@ export async function POST(request: NextRequest) {
   // Login-time MFA verification
   const valid = await verifyMfaCode(session.user.id, code);
   if (!valid) {
+    const { remaining } = recordFailure(rateLimitKey);
     await audit({
       userId: session.user.id,
       action: "auth.mfa_failed",
       resource: "mfa",
-      detail: { phase: "login" },
+      detail: { phase: "login", attemptsRemaining: remaining },
       request,
     });
     return NextResponse.json({ error: "Invalid code" }, { status: 400 });
   }
 
+  resetAttempts(rateLimitKey);
   await audit({
     userId: session.user.id,
     action: "auth.mfa_verified",

--- a/src/app/api/mfa/verify/route.ts
+++ b/src/app/api/mfa/verify/route.ts
@@ -29,7 +29,10 @@ export async function POST(request: NextRequest) {
     });
     return NextResponse.json(
       { error: "Too many attempts. Try again later." },
-      { status: 429 },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil(limit.retryAfterMs! / 1000)) },
+      },
     );
   }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -22,6 +22,7 @@ export const auditActionEnum = pgEnum("audit_action", [
   "auth.mfa_verified",
   "auth.mfa_disabled",
   "auth.mfa_failed",
+  "auth.mfa_rate_limited",
   "data.read",
   "data.create",
   "data.update",

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -9,6 +9,7 @@ export type AuditAction =
   | "auth.mfa_verified"
   | "auth.mfa_disabled"
   | "auth.mfa_failed"
+  | "auth.mfa_rate_limited"
   | "data.read"
   | "data.create"
   | "data.update"

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -9,7 +9,6 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     Google({
       clientId: process.env.GOOGLE_CLIENT_ID!,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
-      allowDangerousEmailAccountLinking: true,
       checks: ["state"],
     }),
     Email({

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,53 @@
+const attempts = new Map<string, { count: number; lockedUntil: number | null }>();
+
+const MAX_ATTEMPTS = 5;
+const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
+const CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+let lastCleanup = Date.now();
+
+function cleanupExpired(): void {
+  const now = Date.now();
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+  for (const [key, entry] of attempts) {
+    if (entry.lockedUntil && entry.lockedUntil <= now) {
+      attempts.delete(key);
+    }
+  }
+}
+
+export function checkRateLimit(key: string): { allowed: boolean; remaining: number; retryAfterMs?: number } {
+  cleanupExpired();
+  const entry = attempts.get(key);
+
+  if (!entry) {
+    return { allowed: true, remaining: MAX_ATTEMPTS };
+  }
+
+  if (entry.lockedUntil) {
+    const now = Date.now();
+    if (now < entry.lockedUntil) {
+      return { allowed: false, remaining: 0, retryAfterMs: entry.lockedUntil - now };
+    }
+    attempts.delete(key);
+    return { allowed: true, remaining: MAX_ATTEMPTS };
+  }
+
+  return { allowed: true, remaining: MAX_ATTEMPTS - entry.count };
+}
+
+export function recordFailure(key: string): { remaining: number } {
+  const entry = attempts.get(key) ?? { count: 0, lockedUntil: null };
+  entry.count += 1;
+
+  if (entry.count >= MAX_ATTEMPTS) {
+    entry.lockedUntil = Date.now() + LOCKOUT_MS;
+  }
+
+  attempts.set(key, entry);
+  return { remaining: Math.max(0, MAX_ATTEMPTS - entry.count) };
+}
+
+export function resetAttempts(key: string): void {
+  attempts.delete(key);
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,4 +1,4 @@
-const attempts = new Map<string, { count: number; lockedUntil: number | null }>();
+const attempts = new Map<string, { count: number; lockedUntil: number | null; lastAttempt: number }>();
 
 const MAX_ATTEMPTS = 5;
 const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
@@ -11,6 +11,8 @@ function cleanupExpired(): void {
   lastCleanup = now;
   for (const [key, entry] of attempts) {
     if (entry.lockedUntil && entry.lockedUntil <= now) {
+      attempts.delete(key);
+    } else if (!entry.lockedUntil && now - entry.lastAttempt > LOCKOUT_MS) {
       attempts.delete(key);
     }
   }
@@ -37,8 +39,9 @@ export function checkRateLimit(key: string): { allowed: boolean; remaining: numb
 }
 
 export function recordFailure(key: string): { remaining: number } {
-  const entry = attempts.get(key) ?? { count: 0, lockedUntil: null };
+  const entry = attempts.get(key) ?? { count: 0, lockedUntil: null, lastAttempt: 0 };
   entry.count += 1;
+  entry.lastAttempt = Date.now();
 
   if (entry.count >= MAX_ATTEMPTS) {
     entry.lockedUntil = Date.now() + LOCKOUT_MS;


### PR DESCRIPTION
## Summary

- **#61**: Removed `allowDangerousEmailAccountLinking: true` from the Google OAuth provider, preventing unauthorized account takeover via email matching.
- **#62**: Added per-user rate limiting to the MFA verification endpoint — 5 attempts before a 15-minute lockout, with `auth.mfa_rate_limited` audit events and accurate remaining-attempt tracking. Includes periodic cleanup of expired entries to prevent memory growth.

### Files changed

- `src/lib/auth.ts` — removed dangerous flag from Google provider
- `src/lib/rate-limit.ts` — new in-memory rate limiter (5 attempts / 15 min lockout)
- `src/app/api/mfa/verify/route.ts` — wired rate limiting into both enrollment and login MFA paths
- `src/lib/audit.ts` + `src/db/schema.ts` — added `auth.mfa_rate_limited` audit action

### Notes

- Rate limiting is in-memory (per-instance). Appropriate for current single-instance deployment. If scaling to multiple instances, migrate to Redis or DB-backed approach.
- Schema change requires `drizzle-kit push` to add the new enum value to Postgres.

## Test plan

- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 100 existing tests pass (`vitest run`)
- [ ] Manual: attempt MFA verification 5+ times with wrong code — verify 429 after 5 failures
- [ ] Manual: wait 15 min (or adjust `LOCKOUT_MS` temporarily) — verify lockout expires
- [ ] Manual: verify Google OAuth login still works without email account linking
- [ ] Run `drizzle-kit push` to apply the new audit enum value

Closes #61, closes #62

/simplify and /weigh-development-paths used during implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)