### PR TITLE
fix(security): require authenticated link code for Telegram linking

### DIFF
--- a/src/app/api/telegram/link-token/route.ts
+++ b/src/app/api/telegram/link-token/route.ts
@@ -1,0 +1,68 @@
+import { NextResponse } from "next/server";
+import { randomBytes } from "crypto";
+import { auth } from "@/lib/auth";
+import { db } from "@/db";
+import { telegramLinkTokens } from "@/db/schema";
+import { eq, and, gt, isNull } from "drizzle-orm";
+import { audit } from "@/lib/audit";
+
+const TOKEN_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+function generateLinkCode(): string {
+  const chars = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+  const bytes = randomBytes(6);
+  let code = "";
+  for (let i = 0; i < 6; i++) {
+    code += chars[bytes[i] % chars.length];
+  }
+  return code;
+}
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  const existing = await db
+    .select({ token: telegramLinkTokens.token, expires: telegramLinkTokens.expires })
+    .from(telegramLinkTokens)
+    .where(
+      and(
+        eq(telegramLinkTokens.userId, session.user.id),
+        gt(telegramLinkTokens.expires, now),
+        isNull(telegramLinkTokens.usedAt)
+      )
+    )
+    .limit(1);
+
+  if (existing.length > 0) {
+    return NextResponse.json({
+      token: existing[0].token,
+      expiresAt: existing[0].expires.toISOString(),
+    });
+  }
+
+  const token = generateLinkCode();
+  const expires = new Date(Date.now() + TOKEN_TTL_MS);
+
+  await Promise.all([
+    db.insert(telegramLinkTokens).values({
+      userId: session.user.id,
+      token,
+      expires,
+    }),
+    audit({
+      userId: session.user.id,
+      action: "telegram.link_initiated",
+      resource: "telegram_link_tokens",
+      request,
+    }),
+  ]);
+
+  return NextResponse.json({
+    token,
+    expiresAt: expires.toISOString(),
+  });
+}

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -5,6 +5,7 @@ import { eq, and, gt, isNull } from "drizzle-orm";
 import { sendTelegramMessage } from "@/lib/telegram";
 import { timingSafeCompare } from "@/lib/validation";
 import { audit } from "@/lib/audit";
+import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
 
 interface TelegramUpdate {
   message?: {
@@ -56,10 +57,19 @@ export async function POST(request: NextRequest) {
 
     const code = parts[1].toUpperCase().trim();
 
+    // Rate limit failed /start attempts per chatId
+    const rateLimitKey = `telegram-link:${chatId}`;
+    const limit = checkRateLimit(rateLimitKey);
+    if (!limit.allowed) {
+      await sendTelegramMessage(chatId, "Too many attempts. Try again later.");
+      return NextResponse.json({ ok: true });
+    }
+
+    // Atomic: validate + mark as used in a single UPDATE...RETURNING to prevent TOCTOU races
     const now = new Date();
-    const [linkToken] = await db
-      .select({ id: telegramLinkTokens.id, userId: telegramLinkTokens.userId })
-      .from(telegramLinkTokens)
+    const result = await db
+      .update(telegramLinkTokens)
+      .set({ usedAt: now })
       .where(
         and(
           eq(telegramLinkTokens.token, code),
@@ -67,9 +77,10 @@ export async function POST(request: NextRequest) {
           isNull(telegramLinkTokens.usedAt)
         )
       )
-      .limit(1);
+      .returning({ id: telegramLinkTokens.id, userId: telegramLinkTokens.userId });
 
-    if (!linkToken) {
+    if (result.length === 0) {
+      recordFailure(rateLimitKey);
       await Promise.all([
         audit({
           action: "telegram.link_failed",
@@ -84,16 +95,13 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: true });
     }
 
-    // Mark token as used
-    await db
-      .update(telegramLinkTokens)
-      .set({ usedAt: now })
-      .where(eq(telegramLinkTokens.id, linkToken.id));
+    const { userId } = result[0];
+    resetAttempts(rateLimitKey);
 
     // Upsert telegram config
     await db
       .insert(telegramConfigs)
-      .values({ userId: linkToken.userId, chatId, enabled: true })
+      .values({ userId, chatId, enabled: true })
       .onConflictDoUpdate({
         target: telegramConfigs.userId,
         set: { chatId, enabled: true },
@@ -101,7 +109,7 @@ export async function POST(request: NextRequest) {
 
     await Promise.all([
       audit({
-        userId: linkToken.userId,
+        userId,
         action: "telegram.link_completed",
         resource: "telegram_configs",
         detail: { chatId },

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
-import { telegramConfigs, users } from "@/db/schema";
-import { eq, and } from "drizzle-orm";
+import { telegramConfigs, telegramLinkTokens } from "@/db/schema";
+import { eq, and, gt, isNull } from "drizzle-orm";
 import { sendTelegramMessage } from "@/lib/telegram";
 import { timingSafeCompare } from "@/lib/validation";
+import { audit } from "@/lib/audit";
 
 interface TelegramUpdate {
   message?: {
@@ -38,53 +39,82 @@ export async function POST(request: NextRequest) {
   const text = update.message.text.trim();
 
   if (text.startsWith("/start")) {
-    // /start <user_email> — link Telegram to account
+    // /start <link_code> — link Telegram via one-time code from the web app
     const parts = text.split(" ");
     if (parts.length < 2) {
       await sendTelegramMessage(
         chatId,
         "Welcome to Really Personal Finance!\n\n" +
-          "To link your account, send:\n" +
-          "<code>/start your@email.com</code>\n\n" +
-          "Use the same email you signed up with."
+          "To link your account:\n" +
+          "1. Log in at the website\n" +
+          "2. Go to Settings > Telegram Alerts\n" +
+          "3. Click \"Generate Link Code\"\n" +
+          "4. Send: /start YOUR_CODE"
       );
       return NextResponse.json({ ok: true });
     }
 
-    const email = parts[1].toLowerCase();
+    const code = parts[1].toUpperCase().trim();
 
-    // Find user by email
-    const [user] = await db
-      .select()
-      .from(users)
-      .where(and(eq(users.email, email), eq(users.isCurrent, true)))
+    const now = new Date();
+    const [linkToken] = await db
+      .select({ id: telegramLinkTokens.id, userId: telegramLinkTokens.userId })
+      .from(telegramLinkTokens)
+      .where(
+        and(
+          eq(telegramLinkTokens.token, code),
+          gt(telegramLinkTokens.expires, now),
+          isNull(telegramLinkTokens.usedAt)
+        )
+      )
       .limit(1);
 
-    if (!user) {
-      await sendTelegramMessage(
-        chatId,
-        "No account found for that email. Make sure you've signed up at the website first."
-      );
+    if (!linkToken) {
+      await Promise.all([
+        audit({
+          action: "telegram.link_failed",
+          resource: "telegram_link_tokens",
+          detail: { chatId, reason: "invalid_or_expired_token" },
+        }),
+        sendTelegramMessage(
+          chatId,
+          "Invalid or expired code. Please generate a new one from the website Settings page."
+        ),
+      ]);
       return NextResponse.json({ ok: true });
     }
+
+    // Mark token as used
+    await db
+      .update(telegramLinkTokens)
+      .set({ usedAt: now })
+      .where(eq(telegramLinkTokens.id, linkToken.id));
 
     // Upsert telegram config
     await db
       .insert(telegramConfigs)
-      .values({ userId: user.userId, chatId, enabled: true })
+      .values({ userId: linkToken.userId, chatId, enabled: true })
       .onConflictDoUpdate({
         target: telegramConfigs.userId,
         set: { chatId, enabled: true },
       });
 
-    await sendTelegramMessage(
-      chatId,
-      "Linked! You'll now receive spending alerts here.\n\n" +
-        "Commands:\n" +
-        "/summary — Today's spending summary\n" +
-        "/pause — Pause alerts\n" +
-        "/resume — Resume alerts"
-    );
+    await Promise.all([
+      audit({
+        userId: linkToken.userId,
+        action: "telegram.link_completed",
+        resource: "telegram_configs",
+        detail: { chatId },
+      }),
+      sendTelegramMessage(
+        chatId,
+        "Linked! You'll now receive spending alerts here.\n\n" +
+          "Commands:\n" +
+          "/summary — Today's spending summary\n" +
+          "/pause — Pause alerts\n" +
+          "/resume — Resume alerts"
+      ),
+    ]);
     return NextResponse.json({ ok: true });
   }
 
@@ -117,7 +147,7 @@ export async function POST(request: NextRequest) {
     if (!config) {
       await sendTelegramMessage(
         chatId,
-        "You haven't linked your account yet. Send /start your@email.com"
+        "You haven't linked your account yet. Log in at the website, go to Settings, and generate a link code."
       );
       return NextResponse.json({ ok: true });
     }

--- a/src/app/dashboard/settings/page.tsx
+++ b/src/app/dashboard/settings/page.tsx
@@ -33,13 +33,13 @@ export default function SettingsPage() {
     null
   );
   const [telegramLoading, setTelegramLoading] = useState(true);
-  const [chatIdInput, setChatIdInput] = useState("");
-  const [telegramSaving, setTelegramSaving] = useState(false);
   const [telegramTesting, setTelegramTesting] = useState(false);
   const [telegramMessage, setTelegramMessage] = useState<{
     type: "success" | "error";
     text: string;
   } | null>(null);
+  const [linkCode, setLinkCode] = useState<string | null>(null);
+  const [linkCodeLoading, setLinkCodeLoading] = useState(false);
 
   // -- Accounts state --
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -61,9 +61,6 @@ export default function SettingsPage() {
       const res = await fetch("/api/telegram/config");
       const json = await res.json();
       setTelegramConfig(json.config || null);
-      if (json.config) {
-        setChatIdInput(json.config.chatId);
-      }
     } catch {
       console.error("Failed to fetch Telegram config");
     }
@@ -89,31 +86,6 @@ export default function SettingsPage() {
   }, [fetchTelegramConfig, fetchAccounts]);
 
   // -- Telegram handlers --
-  async function saveTelegramConfig() {
-    setTelegramSaving(true);
-    setTelegramMessage(null);
-    try {
-      const res = await fetch("/api/telegram/config", {
-        method: "PUT",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ chatId: chatIdInput.trim() }),
-      });
-      const json = await res.json();
-      if (!res.ok) {
-        setTelegramMessage({
-          type: "error",
-          text: json.error || "Failed to save",
-        });
-      } else {
-        setTelegramConfig(json.config);
-        setTelegramMessage({ type: "success", text: "Telegram connected!" });
-      }
-    } catch {
-      setTelegramMessage({ type: "error", text: "Network error" });
-    }
-    setTelegramSaving(false);
-  }
-
   async function toggleTelegramEnabled() {
     if (!telegramConfig) return;
     setTelegramMessage(null);
@@ -142,7 +114,6 @@ export default function SettingsPage() {
       const res = await fetch("/api/telegram/config", { method: "DELETE" });
       if (res.ok) {
         setTelegramConfig(null);
-        setChatIdInput("");
         setTelegramMessage({
           type: "success",
           text: "Telegram disconnected",
@@ -174,6 +145,26 @@ export default function SettingsPage() {
       setTelegramMessage({ type: "error", text: "Network error" });
     }
     setTelegramTesting(false);
+  }
+
+  async function generateLinkCode() {
+    setLinkCodeLoading(true);
+    setTelegramMessage(null);
+    try {
+      const res = await fetch("/api/telegram/link-token", { method: "POST" });
+      const json = await res.json();
+      if (res.ok) {
+        setLinkCode(json.token);
+      } else {
+        setTelegramMessage({
+          type: "error",
+          text: json.error || "Failed to generate code",
+        });
+      }
+    } catch {
+      setTelegramMessage({ type: "error", text: "Network error" });
+    }
+    setLinkCodeLoading(false);
   }
 
   // -- Account handlers --
@@ -298,36 +289,53 @@ export default function SettingsPage() {
             <div className="bg-background-elevated rounded-lg p-4 text-sm text-foreground-muted space-y-2">
               <p className="font-medium text-foreground">How to connect:</p>
               <ol className="list-decimal list-inside space-y-1">
+                <li>Click &quot;Generate Link Code&quot; below</li>
                 <li>
-                  Open Telegram and message your bot with{" "}
+                  Open Telegram and message the bot with{" "}
                   <code className="bg-black/20 px-1 rounded">
-                    /start your@email.com
+                    /start YOUR_CODE
                   </code>
                 </li>
-                <li>
-                  The bot will reply with your chat ID, or you can find it using{" "}
-                  <code className="bg-black/20 px-1 rounded">@userinfobot</code>
-                </li>
-                <li>Enter your chat ID below and save</li>
+                <li>The bot will confirm the link</li>
               </ol>
             </div>
 
-            <div className="flex gap-2">
-              <input
-                type="text"
-                value={chatIdInput}
-                onChange={(e) => setChatIdInput(e.target.value)}
-                placeholder="Enter your Telegram chat ID"
-                className="flex-1 px-3 py-2 border border-border rounded-lg text-sm bg-background-elevated text-foreground placeholder:text-foreground-tertiary"
-              />
+            {linkCode ? (
+              <div className="space-y-2">
+                <div className="flex items-center gap-3">
+                  <span className="text-sm text-foreground-muted">
+                    Your link code:
+                  </span>
+                  <code className="text-lg font-bold bg-background-elevated px-3 py-1 rounded tracking-widest">
+                    {linkCode}
+                  </code>
+                </div>
+                <p className="text-xs text-foreground-tertiary">
+                  Send{" "}
+                  <code className="bg-black/20 px-1 rounded">
+                    /start {linkCode}
+                  </code>{" "}
+                  to the bot in Telegram. Code expires in 10 minutes.
+                </p>
+                <button
+                  onClick={() => {
+                    setLinkCode(null);
+                    fetchTelegramConfig();
+                  }}
+                  className="text-sm text-accent hover:underline"
+                >
+                  Done — refresh status
+                </button>
+              </div>
+            ) : (
               <button
-                onClick={saveTelegramConfig}
-                disabled={!chatIdInput.trim() || telegramSaving}
+                onClick={generateLinkCode}
+                disabled={linkCodeLoading}
                 className="px-4 py-2 text-sm font-medium bg-accent text-white rounded-lg hover:bg-accent-hover transition-all duration-150 active:scale-95 disabled:opacity-50 disabled:cursor-not-allowed"
               >
-                {telegramSaving ? "Saving..." : "Connect"}
+                {linkCodeLoading ? "Generating..." : "Generate Link Code"}
               </button>
-            </div>
+            )}
           </div>
         )}
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -32,6 +32,9 @@ export const auditActionEnum = pgEnum("audit_action", [
   "plaid.token_access",
   "consent.granted",
   "consent.revoked",
+  "telegram.link_initiated",
+  "telegram.link_completed",
+  "telegram.link_failed",
   "admin.role_change",
   "admin.user_deprovisioned",
   "admin.access_review",
@@ -186,6 +189,23 @@ export const telegramConfigs = pgTable(
   },
   (table) => [
     index("idx_telegram_configs_user_id").on(table.userId),
+  ]
+);
+
+// ─── Telegram Link Tokens ────────────────────────────────────────────────────
+export const telegramLinkTokens = pgTable(
+  "telegram_link_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id").notNull(),
+    token: text("token").notNull().unique(),
+    expires: timestamp("expires", { mode: "date" }).notNull(),
+    usedAt: timestamp("used_at", { mode: "date" }),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_telegram_link_tokens_token").on(table.token),
+    index("idx_telegram_link_tokens_user_id").on(table.userId),
   ]
 );
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -19,6 +19,9 @@ export type AuditAction =
   | "plaid.token_access"
   | "consent.granted"
   | "consent.revoked"
+  | "telegram.link_initiated"
+  | "telegram.link_completed"
+  | "telegram.link_failed"
   | "admin.role_change"
   | "admin.user_deprovisioned"
   | "admin.access_review";

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,56 @@
+const attempts = new Map<string, { count: number; lockedUntil: number | null; lastAttempt: number }>();
+
+const MAX_ATTEMPTS = 5;
+const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
+const CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
+let lastCleanup = Date.now();
+
+function cleanupExpired(): void {
+  const now = Date.now();
+  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
+  lastCleanup = now;
+  for (const [key, entry] of attempts) {
+    if (entry.lockedUntil && entry.lockedUntil <= now) {
+      attempts.delete(key);
+    } else if (!entry.lockedUntil && now - entry.lastAttempt > LOCKOUT_MS) {
+      attempts.delete(key);
+    }
+  }
+}
+
+export function checkRateLimit(key: string): { allowed: boolean; remaining: number; retryAfterMs?: number } {
+  cleanupExpired();
+  const entry = attempts.get(key);
+
+  if (!entry) {
+    return { allowed: true, remaining: MAX_ATTEMPTS };
+  }
+
+  if (entry.lockedUntil) {
+    const now = Date.now();
+    if (now < entry.lockedUntil) {
+      return { allowed: false, remaining: 0, retryAfterMs: entry.lockedUntil - now };
+    }
+    attempts.delete(key);
+    return { allowed: true, remaining: MAX_ATTEMPTS };
+  }
+
+  return { allowed: true, remaining: MAX_ATTEMPTS - entry.count };
+}
+
+export function recordFailure(key: string): { remaining: number } {
+  const entry = attempts.get(key) ?? { count: 0, lockedUntil: null, lastAttempt: 0 };
+  entry.count += 1;
+  entry.lastAttempt = Date.now();
+
+  if (entry.count >= MAX_ATTEMPTS) {
+    entry.lockedUntil = Date.now() + LOCKOUT_MS;
+  }
+
+  attempts.set(key, entry);
+  return { remaining: Math.max(0, MAX_ATTEMPTS - entry.count) };
+}
+
+export function resetAttempts(key: string): void {
+  attempts.delete(key);
+}


### PR DESCRIPTION
## Summary

- **Security fix**: The `/start <email>` Telegram command allowed any Telegram user to link to any account by knowing the target's email — zero authentication required. An attacker could hijack a victim's Telegram alerts and issue commands as them.
- **New flow**: User generates a one-time 6-char link code from the authenticated web app (Settings > Telegram Alerts), then sends `/start <code>` to the bot. Code expires in 10 minutes, single-use.
- Adds `telegram_link_tokens` table, `POST /api/telegram/link-token` endpoint (session-authenticated), audit logging for all link attempts (initiated/completed/failed).

Closes #63

## Changes

| File | What |
|------|------|
| `src/db/schema.ts` | Add `telegramLinkTokens` table + 3 new audit action enum values |
| `src/lib/audit.ts` | Add `telegram.link_*` to `AuditAction` type |
| `src/app/api/telegram/link-token/route.ts` | New authenticated endpoint to generate link codes |
| `src/app/api/telegram/webhook/route.ts` | Rewrite `/start` to validate tokens instead of emails |
| `src/app/dashboard/settings/page.tsx` | Replace email instructions with "Generate Link Code" UI |

## Deploy notes

Run `npx drizzle-kit push` to create the `telegram_link_tokens` table and add the new `audit_action` enum values. No data migration needed — existing linked accounts are unaffected.

## Test plan

- [ ] Generate a link code from Settings page while logged in
- [ ] Send `/start <code>` to the bot in Telegram — should link successfully
- [ ] Send `/start` with no code — should show instructions to generate from web app
- [ ] Send `/start BADCODE` — should reject with "invalid or expired" message
- [ ] Wait 10+ minutes and try an old code — should reject as expired
- [ ] Use a valid code twice — second attempt should reject (single-use)
- [ ] Verify existing `/pause`, `/resume`, `/summary` commands still work
- [ ] Verify Settings page shows connected state after linking
- [ ] Check `audit_logs` table for `telegram.link_initiated`, `telegram.link_completed`, `telegram.link_failed` entries