### PR TITLE
refactor(api): extract requireUser/requireAdmin helpers (#81, #82)

### DIFF
--- a/src/__tests__/api-helpers.test.ts
+++ b/src/__tests__/api-helpers.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/rbac", () => ({
+  getUserRole: vi.fn(),
+  hasMinRole: vi.fn((role: string, min: string) => {
+    const hierarchy: Record<string, number> = {
+      owner: 40,
+      admin: 30,
+      member: 20,
+      viewer: 10,
+    };
+    return (hierarchy[role] ?? 0) >= (hierarchy[min] ?? 0);
+  }),
+}));
+
+import { auth } from "@/lib/auth";
+import { getUserRole } from "@/lib/rbac";
+import {
+  requireUser,
+  requireAdmin,
+  requireRole,
+  withErrorHandling,
+} from "@/lib/api-helpers";
+
+const mockedAuth = vi.mocked(auth);
+const mockedGetUserRole = vi.mocked(getUserRole);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("requireUser", () => {
+  it("returns guard when session has a user id", async () => {
+    mockedAuth.mockResolvedValueOnce({
+      user: { id: "u1", email: "a@b.c" },
+      expires: "9999-12-31",
+    } as never);
+
+    const result = await requireUser();
+    if (result instanceof NextResponse) throw new Error("expected guard");
+    expect(result.userId).toBe("u1");
+    expect(result.session.user.id).toBe("u1");
+  });
+
+  it("returns 401 NextResponse when session is null", async () => {
+    mockedAuth.mockResolvedValueOnce(null as never);
+
+    const result = await requireUser();
+    expect(result).toBeInstanceOf(NextResponse);
+    if (!(result instanceof NextResponse)) return;
+    expect(result.status).toBe(401);
+    const body = await result.json();
+    expect(body).toEqual({ error: "Unauthorized" });
+  });
+
+  it("returns 401 when session has no user id", async () => {
+    mockedAuth.mockResolvedValueOnce({
+      user: { email: "a@b.c" },
+      expires: "9999-12-31",
+    } as never);
+
+    const result = await requireUser();
+    expect(result).toBeInstanceOf(NextResponse);
+    if (!(result instanceof NextResponse)) return;
+    expect(result.status).toBe(401);
+  });
+});
+
+describe("requireRole / requireAdmin", () => {
+  it("returns guard with role when user meets minimum", async () => {
+    mockedAuth.mockResolvedValueOnce({
+      user: { id: "u1", email: "a@b.c" },
+      expires: "9999-12-31",
+    } as never);
+    mockedGetUserRole.mockResolvedValueOnce("admin");
+
+    const result = await requireAdmin();
+    if (result instanceof NextResponse) throw new Error("expected guard");
+    expect(result.userId).toBe("u1");
+    expect(result.role).toBe("admin");
+  });
+
+  it("returns 403 when user lacks role", async () => {
+    mockedAuth.mockResolvedValueOnce({
+      user: { id: "u1", email: "a@b.c" },
+      expires: "9999-12-31",
+    } as never);
+    mockedGetUserRole.mockResolvedValueOnce("member");
+
+    const result = await requireAdmin();
+    expect(result).toBeInstanceOf(NextResponse);
+    if (!(result instanceof NextResponse)) return;
+    expect(result.status).toBe(403);
+    const body = await result.json();
+    expect(body).toEqual({ error: "Forbidden" });
+  });
+
+  it("returns 401 when unauthenticated (short-circuits role check)", async () => {
+    mockedAuth.mockResolvedValueOnce(null as never);
+
+    const result = await requireAdmin();
+    expect(result).toBeInstanceOf(NextResponse);
+    if (!(result instanceof NextResponse)) return;
+    expect(result.status).toBe(401);
+    expect(mockedGetUserRole).not.toHaveBeenCalled();
+  });
+
+  it("requireRole('owner') rejects an admin", async () => {
+    mockedAuth.mockResolvedValueOnce({
+      user: { id: "u1", email: "a@b.c" },
+      expires: "9999-12-31",
+    } as never);
+    mockedGetUserRole.mockResolvedValueOnce("admin");
+
+    const result = await requireRole("owner");
+    expect(result).toBeInstanceOf(NextResponse);
+    if (!(result instanceof NextResponse)) return;
+    expect(result.status).toBe(403);
+  });
+});
+
+describe("withErrorHandling", () => {
+  it("returns handler's response on success", async () => {
+    const handler = async (_req: Request): Promise<Response> =>
+      NextResponse.json({ ok: true }, { status: 200 });
+    const wrapped = withErrorHandling(handler);
+    const req = new Request("https://example.com/api/x");
+    const res = await wrapped(req);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+
+  it("converts thrown errors to 500 without leaking the stack", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = async (_req: Request): Promise<Response> => {
+      throw new Error("secret stack trace");
+    };
+    const wrapped = withErrorHandling(handler);
+    const req = new Request("https://example.com/api/x");
+    const res = await wrapped(req);
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body).toEqual({ error: "Internal server error" });
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("converts thrown non-Error values to 500", async () => {
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const handler = async (_req: Request): Promise<Response> => {
+      throw "string error";
+    };
+    const wrapped = withErrorHandling(handler);
+    const req = new Request("https://example.com/api/x");
+    const res = await wrapped(req);
+    expect(res.status).toBe(500);
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts, transactions } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
@@ -8,10 +8,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { id } = await params;
   const body = await request.json();
@@ -45,10 +44,9 @@ export async function DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { id } = await params;
   const userId = session.user.id;

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { validateAccountInput } from "@/lib/validation";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const userAccounts = await db
     .select({
@@ -27,10 +26,9 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const result = validateAccountInput(body);

--- a/src/app/api/admin/audit-logs/route.ts
+++ b/src/app/api/admin/audit-logs/route.ts
@@ -1,21 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import { getUserRole, hasMinRole } from "@/lib/rbac";
+import { requireAdmin } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { auditLogs } from "@/db/schema";
 import { desc, eq } from "drizzle-orm";
 import { clampInt } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const role = await getUserRole(session.user.id);
-  if (!hasMinRole(role, "admin")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { searchParams } = request.nextUrl;
   const limit = clampInt(searchParams.get("limit"), 50, 1, 200);

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,21 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
-import { getUserRole, setUserRole, hasMinRole, VALID_ROLES } from "@/lib/rbac";
+import { requireAdmin } from "@/lib/api-helpers";
+import { setUserRole, hasMinRole, VALID_ROLES } from "@/lib/rbac";
 import { audit } from "@/lib/audit";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const role = await getUserRole(session.user.id);
-  if (!hasMinRole(role, "admin")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const allUsers = await db
     .select({
@@ -41,15 +35,9 @@ export async function GET() {
 }
 
 export async function PATCH(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  const callerRole = await getUserRole(session.user.id);
-  if (!hasMinRole(callerRole, "admin")) {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+  const { session, role: callerRole } = guard;
 
   const body = await request.json();
   const { targetUserId, role, action } = body;

--- a/src/app/api/analytics/income-vs-spending/route.ts
+++ b/src/app/api/analytics/income-vs-spending/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");

--- a/src/app/api/analytics/spending-by-category/route.ts
+++ b/src/app/api/analytics/spending-by-category/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");

--- a/src/app/api/analytics/spending-by-merchant/route.ts
+++ b/src/app/api/analytics/spending-by-merchant/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { clampInt, isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, sql } from "drizzle-orm";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const results = await db
     .select({

--- a/src/app/api/column-mappings/route.ts
+++ b/src/app/api/column-mappings/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { columnMappings } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const mappings = await db
     .select()
@@ -20,10 +19,9 @@ export async function GET() {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { name, columns, dateFormat, amountConvention, skipRows } = body;
@@ -54,10 +52,9 @@ export async function POST(request: NextRequest) {
 }
 
 export async function DELETE(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { searchParams } = request.nextUrl;
   const id = searchParams.get("id");

--- a/src/app/api/consent/history/route.ts
+++ b/src/app/api/consent/history/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { getConsentHistory } from "@/lib/consent";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const history = await getConsentHistory(session.user.id);
   return NextResponse.json({ history });

--- a/src/app/api/consent/route.ts
+++ b/src/app/api/consent/route.ts
@@ -1,23 +1,21 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { grantConsent, revokeConsent, getActiveConsents, VALID_CONSENT_TYPES } from "@/lib/consent";
 import { audit } from "@/lib/audit";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const consents = await getActiveConsents(session.user.id);
   return NextResponse.json({ consents });
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { consentType, version, action } = body;

--- a/src/app/api/data/delete/route.ts
+++ b/src/app/api/data/delete/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { audit } from "@/lib/audit";
 import { db } from "@/db";
 import {
@@ -16,10 +16,9 @@ import {
 import { eq } from "drizzle-orm";
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { confirmation } = body;

--- a/src/app/api/data/export/route.ts
+++ b/src/app/api/data/export/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { audit } from "@/lib/audit";
 import { db } from "@/db";
 import { users, accounts, transactions, consentRecords, columnMappings, telegramConfigs } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const userId = session.user.id;
 

--- a/src/app/api/import/confirm/route.ts
+++ b/src/app/api/import/confirm/route.ts
@@ -1,15 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions, accounts } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { validateConfirmInput } from "@/lib/import";
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
   const userId = session.user.id;
 
   const body = await request.json();

--- a/src/app/api/import/preview/route.ts
+++ b/src/app/api/import/preview/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte } from "drizzle-orm";
@@ -92,10 +92,9 @@ async function findDuplicates(
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const formData = await request.formData();
   const file = formData.get("file") as File | null;

--- a/src/app/api/mfa/disable/route.ts
+++ b/src/app/api/mfa/disable/route.ts
@@ -1,13 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { disableMfa, verifyMfaCode } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { code } = body;

--- a/src/app/api/mfa/enroll/route.ts
+++ b/src/app/api/mfa/enroll/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { enrollMfa } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 
 export async function POST(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { uri, secret, recoveryCodes } = await enrollMfa(
     session.user.id,

--- a/src/app/api/mfa/verify/route.ts
+++ b/src/app/api/mfa/verify/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { confirmMfaEnrollment, verifyMfaCode, hasMfaEnabled } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { code } = body;

--- a/src/app/api/plaid/create-link-token/route.ts
+++ b/src/app/api/plaid/create-link-token/route.ts
@@ -1,13 +1,12 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { plaidClient } from "@/lib/plaid";
 import { CountryCode, Products } from "plaid";
 
 export async function POST() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const products = (process.env.PLAID_PRODUCTS || "transactions")
     .split(",")

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { plaidClient } from "@/lib/plaid";
 import { db } from "@/db";
 import { accounts } from "@/db/schema";
@@ -7,10 +7,9 @@ import { encrypt } from "@/lib/encryption";
 import { audit } from "@/lib/audit";
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { publicToken } = await request.json();
 

--- a/src/app/api/profile/history/route.ts
+++ b/src/app/api/profile/history/route.ts
@@ -1,12 +1,11 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { getUserHistory } from "@/lib/scd2";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const history = await getUserHistory(session.user.id);
 

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,12 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { updateUserProfile } from "@/lib/scd2";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   return NextResponse.json({
     user: {
@@ -18,10 +17,9 @@ export async function GET() {
 }
 
 export async function PUT(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { name, email } = body;

--- a/src/app/api/sync/status/route.ts
+++ b/src/app/api/sync/status/route.ts
@@ -1,14 +1,13 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts, transactions } from "@/db/schema";
 import { eq, and, sql, max } from "drizzle-orm";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   // Check if user has any Plaid accounts
   const plaidAccounts = await db

--- a/src/app/api/sync/trigger/route.ts
+++ b/src/app/api/sync/trigger/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
@@ -8,10 +8,9 @@ import { syncPlaidTransactions } from "@/lib/sync-plaid";
 export const maxDuration = 60;
 
 export async function POST() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const userAccounts = await db
     .select()

--- a/src/app/api/telegram/config/route.ts
+++ b/src/app/api/telegram/config/route.ts
@@ -1,14 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { telegramConfigs } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
 export async function GET() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const [config] = await db
     .select({
@@ -24,10 +23,9 @@ export async function GET() {
 }
 
 export async function PUT(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const body = await request.json();
   const { chatId, enabled } = body as Record<string, unknown>;
@@ -77,10 +75,9 @@ export async function PUT(request: NextRequest) {
 }
 
 export async function DELETE() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   await db
     .delete(telegramConfigs)

--- a/src/app/api/telegram/link-token/route.ts
+++ b/src/app/api/telegram/link-token/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { randomBytes } from "crypto";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { telegramLinkTokens } from "@/db/schema";
 import { eq, and, gt, isNull } from "drizzle-orm";
@@ -19,10 +19,9 @@ function generateLinkCode(): string {
 }
 
 export async function POST(request: Request) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const now = new Date();
   const existing = await db

--- a/src/app/api/telegram/test/route.ts
+++ b/src/app/api/telegram/test/route.ts
@@ -1,15 +1,14 @@
 import { NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { telegramConfigs } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { sendTelegramMessage } from "@/lib/telegram";
 
 export async function POST() {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const [config] = await db
     .select()

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
@@ -8,10 +8,9 @@ export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const { id } = await params;
   const body = await request.json();

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,16 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
-import { auth } from "@/lib/auth";
+import { requireUser } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions, accounts } from "@/db/schema";
 import { eq, and, gte, lte, ilike, desc } from "drizzle-orm";
 import { clampInt, isValidDateParam } from "@/lib/validation";
 
 export async function GET(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
 
   const searchParams = request.nextUrl.searchParams;
   const startDate = searchParams.get("startDate");
@@ -74,10 +73,9 @@ export async function GET(request: NextRequest) {
 }
 
 export async function POST(request: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.id) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const { session } = guard;
   const userId = session.user.id;
 
   const body = await request.json();

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from "next/server";
+import type { Session } from "next-auth";
+import { auth } from "./auth";
+import { getUserRole, hasMinRole, type UserRole } from "./rbac";
+
+export type AuthGuard = { userId: string; session: Session };
+export type RoleGuard = AuthGuard & { role: UserRole };
+
+export async function requireUser(): Promise<AuthGuard | NextResponse> {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return { userId: session.user.id, session };
+}
+
+export async function requireRole(
+  minRole: UserRole,
+): Promise<RoleGuard | NextResponse> {
+  const guard = await requireUser();
+  if (guard instanceof NextResponse) return guard;
+  const role = await getUserRole(guard.userId);
+  if (!hasMinRole(role, minRole)) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+  return { ...guard, role };
+}
+
+export async function requireAdmin(): Promise<RoleGuard | NextResponse> {
+  return requireRole("admin");
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type AnyHandler = (...args: any[]) => Promise<Response> | Response;
+
+export function withErrorHandling<H extends AnyHandler>(handler: H): H {
+  return (async (...args: Parameters<H>) => {
+    try {
+      return await handler(...args);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      const firstArg = args[0] as unknown;
+      const url =
+        firstArg instanceof Request ? firstArg.url : "unknown";
+      console.error(`[api] ${url}: ${message}`);
+      return NextResponse.json(
+        { error: "Internal server error" },
+        { status: 500 },
+      );
+    }
+  }) as H;
+}


### PR DESCRIPTION
## Summary

- Extract `requireUser()` and `requireAdmin()` to `src/lib/api-helpers.ts`, replacing 33 hand-rolled auth/role guards across 29 API route files.
- Each helper returns either a typed guard or a `NextResponse` for the caller to short-circuit on.
- Also adds `withErrorHandling()` (consumed by follow-up #71) plus 10 unit tests covering success, 401, 403, and exception-conversion paths.

Closes #81. Closes #82.

## Why

Before this change, any tweak to the auth contract (MFA enforcement per #73, requiring `emailVerified`, session shape) had to be replicated in 33+ places. New routes copied the snippet, so the guard was opt-in by convention. Now the guard is a single function — and admin routes that previously hand-rolled the role check next to the auth check go through `requireAdmin()`.

Net diff: -55 lines across the API surface, with much better invariant tracking.

## Test plan

- [x] `npm test` — 110 passed (was 100; +10 helper tests)
- [x] `npx tsc --noEmit` — clean (pre-existing `otpauth` type-decl issue unrelated)
- [x] Grep audit: `grep -rn '!session?.user?.id' src/app/api` returns 0 results
- [x] Grep audit: no stray `import { auth } from "@/lib/auth"` in migrated routes (only `[...nextauth]`, cron, and webhook keep their own auth paths)
- [ ] Manual smoke (deferred to reviewer): hit a migrated endpoint authenticated + unauthenticated; hit `/api/admin/users` as non-admin and admin.

## Related

- #71 — `withErrorHandling` wrapper (helper added here, wrapping the 32 routes is a follow-up PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)