### PR TITLE
refactor(api): wrap all routes with withErrorHandling (#71)

### DIFF
--- a/src/app/api/accounts/[id]/route.ts
+++ b/src/app/api/accounts/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts, transactions } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 
-export async function PATCH(
+async function _PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -40,7 +40,7 @@ export async function PATCH(
   return NextResponse.json({ account: updated });
 }
 
-export async function DELETE(
+async function _DELETE(
   _request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -73,3 +73,6 @@ export async function DELETE(
 
   return NextResponse.json({ success: true });
 }
+
+export const PATCH = withErrorHandling(_PATCH);
+export const DELETE = withErrorHandling(_DELETE);

--- a/src/app/api/accounts/route.ts
+++ b/src/app/api/accounts/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { validateAccountInput } from "@/lib/validation";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -25,7 +25,7 @@ export async function GET() {
   return NextResponse.json({ accounts: userAccounts });
 }
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -60,3 +60,6 @@ export async function POST(request: NextRequest) {
     },
   });
 }
+
+export const GET = withErrorHandling(_GET);
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/admin/audit-logs/route.ts
+++ b/src/app/api/admin/audit-logs/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdmin, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { auditLogs } from "@/db/schema";
 import { desc, eq } from "drizzle-orm";
 import { clampInt } from "@/lib/validation";
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const guard = await requireAdmin();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -32,3 +32,5 @@ export async function GET(request: NextRequest) {
 
   return NextResponse.json({ logs, limit, offset });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireAdmin } from "@/lib/api-helpers";
+import { requireAdmin, withErrorHandling } from "@/lib/api-helpers";
 import { setUserRole, hasMinRole, VALID_ROLES } from "@/lib/rbac";
 import { audit } from "@/lib/audit";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireAdmin();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -34,7 +34,7 @@ export async function GET() {
   return NextResponse.json({ users: allUsers });
 }
 
-export async function PATCH(request: NextRequest) {
+async function _PATCH(request: NextRequest) {
   const guard = await requireAdmin();
   if (guard instanceof NextResponse) return guard;
   const { session, role: callerRole } = guard;
@@ -90,3 +90,6 @@ export async function PATCH(request: NextRequest) {
 
   return NextResponse.json({ updated: true });
 }
+
+export const GET = withErrorHandling(_GET);
+export const PATCH = withErrorHandling(_PATCH);

--- a/src/app/api/analytics/income-vs-spending/route.ts
+++ b/src/app/api/analytics/income-vs-spending/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { isValidDateParam } from "@/lib/validation";
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -47,3 +47,5 @@ export async function GET(request: NextRequest) {
     })),
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/analytics/spending-by-category/route.ts
+++ b/src/app/api/analytics/spending-by-category/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { isValidDateParam } from "@/lib/validation";
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -49,3 +49,5 @@ export async function GET(request: NextRequest) {
     })),
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/analytics/spending-by-merchant/route.ts
+++ b/src/app/api/analytics/spending-by-merchant/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte, sql } from "drizzle-orm";
 import { clampInt, isValidDateParam } from "@/lib/validation";
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -53,3 +53,5 @@ export async function GET(request: NextRequest) {
     })),
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/categories/route.ts
+++ b/src/app/api/categories/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, sql } from "drizzle-orm";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -24,3 +24,5 @@ export async function GET() {
 
   return NextResponse.json({ categories });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/column-mappings/route.ts
+++ b/src/app/api/column-mappings/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { columnMappings } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -18,7 +18,7 @@ export async function GET() {
   return NextResponse.json({ mappings });
 }
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -51,7 +51,7 @@ export async function POST(request: NextRequest) {
   return NextResponse.json({ mapping }, { status: 201 });
 }
 
-export async function DELETE(request: NextRequest) {
+async function _DELETE(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -71,3 +71,7 @@ export async function DELETE(request: NextRequest) {
 
   return NextResponse.json({ success: true });
 }
+
+export const GET = withErrorHandling(_GET);
+export const POST = withErrorHandling(_POST);
+export const DELETE = withErrorHandling(_DELETE);

--- a/src/app/api/consent/history/route.ts
+++ b/src/app/api/consent/history/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { getConsentHistory } from "@/lib/consent";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -10,3 +10,5 @@ export async function GET() {
   const history = await getConsentHistory(session.user.id);
   return NextResponse.json({ history });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/consent/route.ts
+++ b/src/app/api/consent/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { grantConsent, revokeConsent, getActiveConsents, VALID_CONSENT_TYPES } from "@/lib/consent";
 import { audit } from "@/lib/audit";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -12,7 +12,7 @@ export async function GET() {
   return NextResponse.json({ consents });
 }
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -54,3 +54,6 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ granted: true });
 }
+
+export const GET = withErrorHandling(_GET);
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/cron/send-alerts/route.ts
+++ b/src/app/api/cron/send-alerts/route.ts
@@ -1,9 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sendDailyAlerts, sendWeeklyAlerts } from "@/lib/alerts";
+import { withErrorHandling } from "@/lib/api-helpers";
 
 export const maxDuration = 60;
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -19,3 +20,5 @@ export async function GET(request: NextRequest) {
   await sendDailyAlerts();
   return NextResponse.json({ success: true, type: "daily" });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/cron/sync-transactions/route.ts
+++ b/src/app/api/cron/sync-transactions/route.ts
@@ -3,10 +3,11 @@ import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { syncPlaidTransactions } from "@/lib/sync-plaid";
 import { audit } from "@/lib/audit";
+import { withErrorHandling } from "@/lib/api-helpers";
 
 export const maxDuration = 300; // 5 minutes for Vercel
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   // Verify cron secret
   const authHeader = request.headers.get("authorization");
   if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
@@ -37,3 +38,5 @@ export async function GET(request: NextRequest) {
     errors: result.errors.length > 0 ? result.errors : undefined,
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/data/delete/route.ts
+++ b/src/app/api/data/delete/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { audit } from "@/lib/audit";
 import { db } from "@/db";
 import {
@@ -15,7 +15,7 @@ import {
 } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -65,3 +65,5 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ deleted: true });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/data/export/route.ts
+++ b/src/app/api/data/export/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { audit } from "@/lib/audit";
 import { db } from "@/db";
 import { users, accounts, transactions, consentRecords, columnMappings, telegramConfigs } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -80,3 +80,5 @@ export async function GET(request: NextRequest) {
     telegramConfig: userTelegram,
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/import/confirm/route.ts
+++ b/src/app/api/import/confirm/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions, accounts } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 import { validateConfirmInput } from "@/lib/import";
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -61,3 +61,5 @@ export async function POST(request: NextRequest) {
     imported: inserted,
   });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/import/preview/route.ts
+++ b/src/app/api/import/preview/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and, gte, lte } from "drizzle-orm";
@@ -91,7 +91,7 @@ async function findDuplicates(
   return duplicates;
 }
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -163,3 +163,5 @@ export async function POST(request: NextRequest) {
     parseErrors: result.errors,
   });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/mfa/disable/route.ts
+++ b/src/app/api/mfa/disable/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { disableMfa, verifyMfaCode } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -32,3 +32,5 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ disabled: true });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/mfa/enroll/route.ts
+++ b/src/app/api/mfa/enroll/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { enrollMfa } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 
-export async function POST(request: Request) {
+async function _POST(request: Request) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -23,3 +23,5 @@ export async function POST(request: Request) {
 
   return NextResponse.json({ uri, secret, recoveryCodes });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/mfa/verify/route.ts
+++ b/src/app/api/mfa/verify/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { confirmMfaEnrollment, verifyMfaCode, hasMfaEnabled } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -89,3 +89,5 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ verified: true });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/plaid/create-link-token/route.ts
+++ b/src/app/api/plaid/create-link-token/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { plaidClient } from "@/lib/plaid";
 import { CountryCode, Products } from "plaid";
 
-export async function POST() {
+async function _POST() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -29,3 +29,5 @@ export async function POST() {
 
   return NextResponse.json({ linkToken: response.data.link_token });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/plaid/exchange-token/route.ts
+++ b/src/app/api/plaid/exchange-token/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { plaidClient } from "@/lib/plaid";
 import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { encrypt } from "@/lib/encryption";
 import { audit } from "@/lib/audit";
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -72,3 +72,5 @@ export async function POST(request: NextRequest) {
     })),
   });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/profile/history/route.ts
+++ b/src/app/api/profile/history/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { getUserHistory } from "@/lib/scd2";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -19,3 +19,5 @@ export async function GET() {
     })),
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { updateUserProfile } from "@/lib/scd2";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -16,7 +16,7 @@ export async function GET() {
   });
 }
 
-export async function PUT(request: NextRequest) {
+async function _PUT(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -52,3 +52,6 @@ export async function PUT(request: NextRequest) {
     },
   });
 }
+
+export const GET = withErrorHandling(_GET);
+export const PUT = withErrorHandling(_PUT);

--- a/src/app/api/sync/status/route.ts
+++ b/src/app/api/sync/status/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts, transactions } from "@/db/schema";
 import { eq, and, sql, max } from "drizzle-orm";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -49,3 +49,5 @@ export async function GET() {
     transactionCount: stats?.count || 0,
   });
 }
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/sync/trigger/route.ts
+++ b/src/app/api/sync/trigger/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
@@ -7,7 +7,7 @@ import { syncPlaidTransactions } from "@/lib/sync-plaid";
 
 export const maxDuration = 60;
 
-export async function POST() {
+async function _POST() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -34,3 +34,5 @@ export async function POST() {
     errors: result.errors.length > 0 ? result.errors : undefined,
   });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/telegram/config/route.ts
+++ b/src/app/api/telegram/config/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { telegramConfigs } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function GET() {
+async function _GET() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -22,7 +22,7 @@ export async function GET() {
   return NextResponse.json({ config: config || null });
 }
 
-export async function PUT(request: NextRequest) {
+async function _PUT(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -74,7 +74,7 @@ export async function PUT(request: NextRequest) {
   return NextResponse.json({ config: updated || null });
 }
 
-export async function DELETE() {
+async function _DELETE() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -85,3 +85,7 @@ export async function DELETE() {
 
   return NextResponse.json({ success: true });
 }
+
+export const GET = withErrorHandling(_GET);
+export const PUT = withErrorHandling(_PUT);
+export const DELETE = withErrorHandling(_DELETE);

--- a/src/app/api/telegram/link-token/route.ts
+++ b/src/app/api/telegram/link-token/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { randomBytes } from "crypto";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { telegramLinkTokens } from "@/db/schema";
 import { eq, and, gt, isNull } from "drizzle-orm";
@@ -18,7 +18,7 @@ function generateLinkCode(): string {
   return code;
 }
 
-export async function POST(request: Request) {
+async function _POST(request: Request) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -65,3 +65,5 @@ export async function POST(request: Request) {
     expiresAt: expires.toISOString(),
   });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/telegram/test/route.ts
+++ b/src/app/api/telegram/test/route.ts
@@ -1,11 +1,11 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { telegramConfigs } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { sendTelegramMessage } from "@/lib/telegram";
 
-export async function POST() {
+async function _POST() {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -37,3 +37,5 @@ export async function POST() {
 
   return NextResponse.json({ success: true });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -6,6 +6,7 @@ import { sendTelegramMessage } from "@/lib/telegram";
 import { timingSafeCompare } from "@/lib/validation";
 import { audit } from "@/lib/audit";
 import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
+import { withErrorHandling } from "@/lib/api-helpers";
 
 interface TelegramUpdate {
   message?: {
@@ -15,7 +16,7 @@ interface TelegramUpdate {
   };
 }
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   // Webhook secret verification
   // Telegram sends X-Telegram-Bot-Api-Secret-Token when registered with secret_token
   const secretToken = request.headers.get("x-telegram-bot-api-secret-token");
@@ -173,3 +174,5 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ ok: true });
 }
+
+export const POST = withErrorHandling(_POST);

--- a/src/app/api/transactions/[id]/route.ts
+++ b/src/app/api/transactions/[id]/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
 
-export async function PATCH(
+async function _PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
@@ -53,3 +53,5 @@ export async function PATCH(
 
   return NextResponse.json({ transaction: updated });
 }
+
+export const PATCH = withErrorHandling(_PATCH);

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { randomUUID } from "crypto";
-import { requireUser } from "@/lib/api-helpers";
+import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { db } from "@/db";
 import { transactions, accounts } from "@/db/schema";
 import { eq, and, gte, lte, ilike, desc } from "drizzle-orm";
 import { clampInt, isValidDateParam } from "@/lib/validation";
 
-export async function GET(request: NextRequest) {
+async function _GET(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -72,7 +72,7 @@ export async function GET(request: NextRequest) {
   return NextResponse.json({ transactions: results });
 }
 
-export async function POST(request: NextRequest) {
+async function _POST(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
   const { session } = guard;
@@ -129,3 +129,6 @@ export async function POST(request: NextRequest) {
 
   return NextResponse.json({ transaction: created }, { status: 201 });
 }
+
+export const GET = withErrorHandling(_GET);
+export const POST = withErrorHandling(_POST);


### PR DESCRIPTION
## Summary

Wrap every API route handler with `withErrorHandling()` (introduced in #88). The internal handler becomes `_METHOD` and the export is `withErrorHandling(_METHOD)`.

Unhandled exceptions — malformed `request.json()`, DB constraint violations, upstream Plaid/Telegram failures — now return a uniform `{ error: "Internal server error" }` 500 instead of leaking the stack trace via Next.js's default unhandled-exception path. The error message is logged server-side with the request URL for triage.

Closes #71. Mitigates the response-leak surface flagged in #69.

## Stacked on #88

This branch is stacked on `tech-debt/auth-helpers`. The PR targets `main`; merge #88 first so this rebases to just the wrap changes.

## What it does NOT do

- Does not convert thrown `JSON.parse` errors to 400. They stay 500 (and now hide the stack). If you want 400 semantics for malformed JSON, wrap `request.json()` in a try/catch inside the handler. That's intentionally out of scope for this PR.
- Does not affect `[...nextauth]/route.ts` — wired by next-auth itself.

## Test plan

- [x] `npm test` — 110 passed (no test changes; behavior-preserving wrap)
- [x] `npx tsc --noEmit` — clean (pre-existing `otpauth` module-not-found unrelated)
- [x] Spot-checked `src/app/api/categories/route.ts`, `src/app/api/cron/send-alerts/route.ts`, `src/app/api/admin/users/route.ts` — wrap shape consistent
- [ ] Manual smoke (deferred to reviewer): hit a wrapped endpoint with a deliberate failure (e.g., POST invalid JSON) and confirm 500 with generic body + log line in server logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)