### PR TITLE
Durable Postgres-backed rate limiter (#75)

### DIFF
--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const selectResult = vi.fn();
+const insertResult = vi.fn();
+const deleteResult = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => selectResult(),
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: () => ({
+        onConflictDoUpdate: () => ({
+          returning: () => insertResult(),
+        }),
+      }),
+    }),
+    delete: () => ({
+      where: () => deleteResult(),
+    }),
+  },
+}));
+
+import {
+  checkRateLimit,
+  recordFailure,
+  resetAttempts,
+  MAX_ATTEMPTS,
+  LOCKOUT_MS,
+} from "@/lib/rate-limit";
+
+beforeEach(() => {
+  selectResult.mockReset();
+  insertResult.mockReset();
+  deleteResult.mockReset();
+  deleteResult.mockResolvedValue(undefined);
+});
+
+describe("checkRateLimit", () => {
+  it("allows with full quota when no row exists", async () => {
+    selectResult.mockResolvedValueOnce([]);
+
+    const result = await checkRateLimit("k");
+
+    expect(result).toEqual({ allowed: true, remaining: MAX_ATTEMPTS });
+  });
+
+  it("returns remaining = MAX - count when row exists without lockout", async () => {
+    selectResult.mockResolvedValueOnce([
+      { key: "k", count: 3, lockedUntil: null, lastAttempt: new Date() },
+    ]);
+
+    const result = await checkRateLimit("k");
+
+    expect(result).toEqual({ allowed: true, remaining: MAX_ATTEMPTS - 3 });
+  });
+
+  it("blocks with retryAfterMs when lockout is in the future", async () => {
+    const lockedUntil = new Date(Date.now() + 10 * 60 * 1000);
+    selectResult.mockResolvedValueOnce([
+      { key: "k", count: MAX_ATTEMPTS, lockedUntil, lastAttempt: new Date() },
+    ]);
+
+    const result = await checkRateLimit("k");
+
+    expect(result.allowed).toBe(false);
+    expect(result.remaining).toBe(0);
+    expect(result.retryAfterMs).toBeGreaterThan(0);
+    expect(result.retryAfterMs).toBeLessThanOrEqual(LOCKOUT_MS);
+  });
+
+  it("clears the row and re-allows once lockout has passed", async () => {
+    const lockedUntil = new Date(Date.now() - 1000);
+    selectResult.mockResolvedValueOnce([
+      { key: "k", count: MAX_ATTEMPTS, lockedUntil, lastAttempt: new Date() },
+    ]);
+
+    const result = await checkRateLimit("k");
+
+    expect(result).toEqual({ allowed: true, remaining: MAX_ATTEMPTS });
+    expect(deleteResult).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("recordFailure", () => {
+  it("returns remaining = MAX - returned count", async () => {
+    insertResult.mockResolvedValueOnce([{ count: 2 }]);
+
+    const result = await recordFailure("k");
+
+    expect(result).toEqual({ remaining: MAX_ATTEMPTS - 2 });
+  });
+
+  it("clamps remaining at 0 when count >= MAX", async () => {
+    insertResult.mockResolvedValueOnce([{ count: MAX_ATTEMPTS }]);
+
+    const result = await recordFailure("k");
+
+    expect(result).toEqual({ remaining: 0 });
+  });
+
+  it("uses a single upsert call (no SELECT-then-UPDATE TOCTOU window)", async () => {
+    insertResult.mockResolvedValueOnce([{ count: 1 }]);
+
+    await recordFailure("k");
+
+    expect(insertResult).toHaveBeenCalledTimes(1);
+    expect(selectResult).not.toHaveBeenCalled();
+  });
+});
+
+describe("resetAttempts", () => {
+  it("issues a delete for the key", async () => {
+    await resetAttempts("k");
+
+    expect(deleteResult).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/app/api/cron/cleanup-rate-limits/route.ts
+++ b/src/app/api/cron/cleanup-rate-limits/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { rateLimitAttempts } from "@/db/schema";
+import { lt } from "drizzle-orm";
+import { withErrorHandling } from "@/lib/api-helpers";
+import { timingSafeCompare } from "@/lib/validation";
+
+async function _GET(request: NextRequest) {
+  const authHeader = request.headers.get("authorization");
+  const expected = `Bearer ${process.env.CRON_SECRET}`;
+  if (!authHeader || !timingSafeCompare(authHeader, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const cutoff = new Date(Date.now() - 60 * 60 * 1000); // 1 hour ago
+  const deleted = await db
+    .delete(rateLimitAttempts)
+    .where(lt(rateLimitAttempts.lastAttempt, cutoff))
+    .returning({ key: rateLimitAttempts.key });
+
+  return NextResponse.json({ deletedCount: deleted.length });
+}
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/mfa/verify/route.ts
+++ b/src/app/api/mfa/verify/route.ts
@@ -17,7 +17,7 @@ async function _POST(request: NextRequest) {
   }
 
   const rateLimitKey = `mfa:${session.user.id}`;
-  const limit = checkRateLimit(rateLimitKey);
+  const limit = await checkRateLimit(rateLimitKey);
   if (!limit.allowed) {
     await audit({
       userId: session.user.id,
@@ -41,7 +41,7 @@ async function _POST(request: NextRequest) {
     // First-time verification during enrollment
     const success = await confirmMfaEnrollment(session.user.id, code);
     if (!success) {
-      const { remaining } = recordFailure(rateLimitKey);
+      const { remaining } = await recordFailure(rateLimitKey);
       await audit({
         userId: session.user.id,
         action: "auth.mfa_failed",
@@ -52,7 +52,7 @@ async function _POST(request: NextRequest) {
       return NextResponse.json({ error: "Invalid code" }, { status: 400 });
     }
 
-    resetAttempts(rateLimitKey);
+    await resetAttempts(rateLimitKey);
     await audit({
       userId: session.user.id,
       action: "auth.mfa_verified",
@@ -67,7 +67,7 @@ async function _POST(request: NextRequest) {
   // Login-time MFA verification
   const valid = await verifyMfaCode(session.user.id, code);
   if (!valid) {
-    const { remaining } = recordFailure(rateLimitKey);
+    const { remaining } = await recordFailure(rateLimitKey);
     await audit({
       userId: session.user.id,
       action: "auth.mfa_failed",
@@ -78,7 +78,7 @@ async function _POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid code" }, { status: 400 });
   }
 
-  resetAttempts(rateLimitKey);
+  await resetAttempts(rateLimitKey);
   await audit({
     userId: session.user.id,
     action: "auth.mfa_verified",

--- a/src/app/api/telegram/webhook/route.ts
+++ b/src/app/api/telegram/webhook/route.ts
@@ -60,7 +60,7 @@ async function _POST(request: NextRequest) {
 
     // Rate limit failed /start attempts per chatId
     const rateLimitKey = `telegram-link:${chatId}`;
-    const limit = checkRateLimit(rateLimitKey);
+    const limit = await checkRateLimit(rateLimitKey);
     if (!limit.allowed) {
       await sendTelegramMessage(chatId, "Too many attempts. Try again later.");
       return NextResponse.json({ ok: true });
@@ -81,7 +81,7 @@ async function _POST(request: NextRequest) {
       .returning({ id: telegramLinkTokens.id, userId: telegramLinkTokens.userId });
 
     if (result.length === 0) {
-      recordFailure(rateLimitKey);
+      await recordFailure(rateLimitKey);
       await Promise.all([
         audit({
           action: "telegram.link_failed",
@@ -97,7 +97,7 @@ async function _POST(request: NextRequest) {
     }
 
     const { userId } = result[0];
-    resetAttempts(rateLimitKey);
+    await resetAttempts(rateLimitKey);
 
     // Upsert telegram config
     await db

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -247,6 +247,20 @@ export const mfaCredentials = pgTable(
   ]
 );
 
+// ─── Rate Limit Attempts ─────────────────────────────────────────────────────
+export const rateLimitAttempts = pgTable(
+  "rate_limit_attempts",
+  {
+    key: text("key").primaryKey(),
+    count: integer("count").notNull().default(0),
+    lockedUntil: timestamp("locked_until", { mode: "date" }),
+    lastAttempt: timestamp("last_attempt", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_rate_limit_attempts_last_attempt").on(table.lastAttempt),
+  ]
+);
+
 // ─── Consent Records ────────────────────────────────────────────────────────
 export const consentRecords = pgTable(
   "consent_records",

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,56 +1,59 @@
-const attempts = new Map<string, { count: number; lockedUntil: number | null; lastAttempt: number }>();
+import { db } from "@/db";
+import { rateLimitAttempts } from "@/db/schema";
+import { eq, sql } from "drizzle-orm";
 
-const MAX_ATTEMPTS = 5;
-const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
-const CLEANUP_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes
-let lastCleanup = Date.now();
+export const MAX_ATTEMPTS = 5;
+export const LOCKOUT_MS = 15 * 60 * 1000; // 15 minutes
 
-function cleanupExpired(): void {
-  const now = Date.now();
-  if (now - lastCleanup < CLEANUP_INTERVAL_MS) return;
-  lastCleanup = now;
-  for (const [key, entry] of attempts) {
-    if (entry.lockedUntil && entry.lockedUntil <= now) {
-      attempts.delete(key);
-    } else if (!entry.lockedUntil && now - entry.lastAttempt > LOCKOUT_MS) {
-      attempts.delete(key);
-    }
-  }
-}
+export async function checkRateLimit(
+  key: string
+): Promise<{ allowed: boolean; remaining: number; retryAfterMs?: number }> {
+  const [row] = await db
+    .select()
+    .from(rateLimitAttempts)
+    .where(eq(rateLimitAttempts.key, key))
+    .limit(1);
 
-export function checkRateLimit(key: string): { allowed: boolean; remaining: number; retryAfterMs?: number } {
-  cleanupExpired();
-  const entry = attempts.get(key);
-
-  if (!entry) {
+  if (!row) {
     return { allowed: true, remaining: MAX_ATTEMPTS };
   }
 
-  if (entry.lockedUntil) {
+  if (row.lockedUntil) {
+    const lockedUntilMs = row.lockedUntil.getTime();
     const now = Date.now();
-    if (now < entry.lockedUntil) {
-      return { allowed: false, remaining: 0, retryAfterMs: entry.lockedUntil - now };
+    if (now < lockedUntilMs) {
+      return { allowed: false, remaining: 0, retryAfterMs: lockedUntilMs - now };
     }
-    attempts.delete(key);
+    // Lockout window passed; clear the row so attempts reset.
+    await db.delete(rateLimitAttempts).where(eq(rateLimitAttempts.key, key));
     return { allowed: true, remaining: MAX_ATTEMPTS };
   }
 
-  return { allowed: true, remaining: MAX_ATTEMPTS - entry.count };
+  return { allowed: true, remaining: Math.max(0, MAX_ATTEMPTS - row.count) };
 }
 
-export function recordFailure(key: string): { remaining: number } {
-  const entry = attempts.get(key) ?? { count: 0, lockedUntil: null, lastAttempt: 0 };
-  entry.count += 1;
-  entry.lastAttempt = Date.now();
+export async function recordFailure(key: string): Promise<{ remaining: number }> {
+  // Atomic upsert: increment count and set lockout when threshold crossed, in one SQL.
+  const [row] = await db
+    .insert(rateLimitAttempts)
+    .values({ key, count: 1, lastAttempt: new Date() })
+    .onConflictDoUpdate({
+      target: rateLimitAttempts.key,
+      set: {
+        count: sql`${rateLimitAttempts.count} + 1`,
+        lastAttempt: sql`NOW()`,
+        lockedUntil: sql`CASE
+          WHEN ${rateLimitAttempts.count} + 1 >= ${MAX_ATTEMPTS}
+          THEN NOW() + (${LOCKOUT_MS} || ' milliseconds')::interval
+          ELSE ${rateLimitAttempts.lockedUntil}
+        END`,
+      },
+    })
+    .returning({ count: rateLimitAttempts.count });
 
-  if (entry.count >= MAX_ATTEMPTS) {
-    entry.lockedUntil = Date.now() + LOCKOUT_MS;
-  }
-
-  attempts.set(key, entry);
-  return { remaining: Math.max(0, MAX_ATTEMPTS - entry.count) };
+  return { remaining: Math.max(0, MAX_ATTEMPTS - row.count) };
 }
 
-export function resetAttempts(key: string): void {
-  attempts.delete(key);
+export async function resetAttempts(key: string): Promise<void> {
+  await db.delete(rateLimitAttempts).where(eq(rateLimitAttempts.key, key));
 }

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/send-alerts?type=weekly",
       "schedule": "0 8 * * 1"
+    },
+    {
+      "path": "/api/cron/cleanup-rate-limits",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
Closes #75.

## Summary

- Replaces the process-local `Map` in `src/lib/rate-limit.ts` with a `rate_limit_attempts` table so MFA + Telegram-link lockouts survive across Fluid Compute instances.
- `recordFailure` is now a **single atomic upsert** (`INSERT … ON CONFLICT (key) DO UPDATE SET count = count + 1, locked_until = CASE …`) — eliminates the SELECT-then-UPDATE TOCTOU window at the lockout boundary.
- `checkRateLimit` / `recordFailure` / `resetAttempts` are now `async` (public names + `MAX_ATTEMPTS=5` / `LOCKOUT_MS=15min` unchanged). Both call sites updated.
- New hourly cron `/api/cron/cleanup-rate-limits` purges rows older than 1 hour. Added to `vercel.json`.

## Decisions (refined during challenge round)

- **PK shape:** `key text PRIMARY KEY` — diverges from the codebase's uuid-PK convention because the key *is* the natural identifier and a uuid column would be unused.
- **Atomicity:** single upsert beats two queries against the Neon HTTP driver (which doesn't support multi-statement transactions for read-then-write logic).
- **Tests:** mock the db client (matches `api-helpers.test.ts` style). No new DB-integration test infrastructure introduced.
- **Cleanup cadence:** hourly retention of 1h, not daily/24h — keeps the table tiny.
- **Cron auth:** the new route uses `timingSafeCompare`. The two existing cron routes still use `!==` and are tracked under #77.

## Schema sync note

This repo uses `npm run db:push` (declarative Drizzle sync), not migration files. **Before deploying, run `npm run db:push` against the production database** to create `rate_limit_attempts`. (`npm run db:generate` would emit a from-scratch migration containing the whole schema, which is not how this project tracks history.)

## Verification

- `npm run test`: 118/118 pass (8 new rate-limit tests).
- `npm run build`: succeeds. `/api/cron/cleanup-rate-limits` registered.
- `npx tsc --noEmit`: clean.
- `npm run lint`: no new issues from changed files (the 9 errors / 14 warnings exist on `main`).

## Test plan (manual)

- [ ] Run `npm run db:push` against staging/prod to create the new table.
- [ ] Trigger 5 invalid MFA codes in quick succession → 6th request gets 429 with `Retry-After`.
- [ ] Force a new Vercel instance (deploy or wait for cold start) → lockout still applies (this is the primary regression we are guarding against).
- [ ] Hit `/api/cron/cleanup-rate-limits` with the cron `Authorization: Bearer $CRON_SECRET` → 200 with `{ deletedCount }`; without auth → 401.

## Follow-up (out of scope)

- #77 — make all cron-route `CRON_SECRET` checks `timingSafeCompare` (this PR did the new one only).
- #73 — MFA verification enforcement post-login (depends on this durable lockout to be meaningful).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
