### PR TITLE
fix(cron): daily rate-limit cleanup (Hobby plan)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -14,7 +14,7 @@
     },
     {
       "path": "/api/cron/cleanup-rate-limits",
-      "schedule": "0 * * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
Fixes the broken production deploy from #91.

Vercel commented on #91 immediately after merge:

> Hobby accounts are limited to daily cron jobs. This cron expression (0 * * * *) would run more than once per day.

Change `0 * * * *` → `0 0 * * *` (midnight UTC). Daily is fine — the route deletes rows older than 1h, lockouts are 15min, and the table size is bounded by failed-MFA + failed-Telegram-link attempts per day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)