### PR TITLE
feat(security): enforce MFA verification after login (closes #73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# local transaction CSVs (user-uploaded test data)
+/transactions/

--- a/src/__tests__/mfa-verify-route.test.ts
+++ b/src/__tests__/mfa-verify-route.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const updateWhere = vi.fn();
+const updateSet = vi.fn(() => ({ where: updateWhere }));
+const updateFrom = vi.fn(() => ({ set: updateSet }));
+
+vi.mock("@/db", () => ({
+  db: {
+    update: vi.fn(() => ({ set: updateSet })),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/mfa", () => ({
+  confirmMfaEnrollment: vi.fn(),
+  verifyMfaCode: vi.fn(),
+  hasMfaEnabled: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  audit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+  recordFailure: vi.fn(),
+  resetAttempts: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { auth } from "@/lib/auth";
+import { confirmMfaEnrollment, verifyMfaCode, hasMfaEnabled } from "@/lib/mfa";
+import { checkRateLimit, recordFailure } from "@/lib/rate-limit";
+import { db } from "@/db";
+import { POST } from "@/app/api/mfa/verify/route";
+
+const mockedAuth = vi.mocked(auth);
+const mockedConfirm = vi.mocked(confirmMfaEnrollment);
+const mockedVerify = vi.mocked(verifyMfaCode);
+const mockedHasMfa = vi.mocked(hasMfaEnabled);
+const mockedCheckRateLimit = vi.mocked(checkRateLimit);
+const mockedRecordFailure = vi.mocked(recordFailure);
+const mockedDbUpdate = vi.mocked(db.update);
+
+function makeRequest(body: Record<string, unknown>, sessionCookie?: string) {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (sessionCookie) {
+    headers["cookie"] = `authjs.session-token=${sessionCookie}`;
+  }
+  return new NextRequest("https://example.com/api/mfa/verify", {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateSet.mockReturnValue({ where: updateWhere });
+  updateWhere.mockResolvedValue(undefined);
+  updateFrom.mockReturnValue({ set: updateSet });
+  mockedDbUpdate.mockReturnValue({ set: updateSet } as never);
+  mockedAuth.mockResolvedValue({
+    user: { id: "u1", email: "a@b.c" },
+    expires: "9999-12-31",
+  } as never);
+  mockedCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 5 });
+});
+
+describe("POST /api/mfa/verify — marks session mfa_verified_at", () => {
+  it("UPDATEs sessions on successful login-phase verify", async () => {
+    mockedHasMfa.mockResolvedValueOnce(true);
+    mockedVerify.mockResolvedValueOnce(true);
+
+    const res = await POST(makeRequest({ code: "123456" }, "tok-login"));
+
+    expect(res.status).toBe(200);
+    expect(mockedDbUpdate).toHaveBeenCalledTimes(1);
+    expect(updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({ mfaVerifiedAt: expect.any(Date) }),
+    );
+  });
+
+  it("UPDATEs sessions on successful enrollment-phase verify", async () => {
+    mockedHasMfa.mockResolvedValueOnce(false);
+    mockedConfirm.mockResolvedValueOnce(true);
+
+    const res = await POST(makeRequest({ code: "123456" }, "tok-enroll"));
+
+    expect(res.status).toBe(200);
+    expect(mockedDbUpdate).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT UPDATE sessions when verify fails", async () => {
+    mockedHasMfa.mockResolvedValueOnce(true);
+    mockedVerify.mockResolvedValueOnce(false);
+    mockedRecordFailure.mockResolvedValueOnce({ remaining: 4 });
+
+    const res = await POST(makeRequest({ code: "wrongcode" }, "tok-bad"));
+
+    expect(res.status).toBe(400);
+    expect(mockedDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does NOT UPDATE sessions when rate limited (no verify attempted)", async () => {
+    mockedCheckRateLimit.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: 60_000,
+    });
+
+    const res = await POST(makeRequest({ code: "123456" }, "tok-blocked"));
+
+    expect(res.status).toBe(429);
+    expect(mockedDbUpdate).not.toHaveBeenCalled();
+    expect(mockedVerify).not.toHaveBeenCalled();
+    expect(mockedConfirm).not.toHaveBeenCalled();
+  });
+
+  it("succeeds without UPDATE when no session cookie is present", async () => {
+    mockedHasMfa.mockResolvedValueOnce(true);
+    mockedVerify.mockResolvedValueOnce(true);
+
+    const res = await POST(makeRequest({ code: "123456" }));
+
+    expect(res.status).toBe(200);
+    expect(mockedDbUpdate).not.toHaveBeenCalled();
+  });
+
+  it("reads the __Secure- cookie variant when present", async () => {
+    mockedHasMfa.mockResolvedValueOnce(true);
+    mockedVerify.mockResolvedValueOnce(true);
+
+    const req = new NextRequest("https://example.com/api/mfa/verify", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        cookie: "__Secure-authjs.session-token=secure-tok",
+      },
+      body: JSON.stringify({ code: "123456" }),
+    });
+
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockedDbUpdate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/middleware-gate.test.ts
+++ b/src/__tests__/middleware-gate.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { evaluateGate, type GateInput } from "@/lib/middleware-gate";
+
+function gate(overrides: Partial<GateInput> = {}) {
+  return evaluateGate({
+    pathname: "/dashboard",
+    isLoggedIn: true,
+    mfaEnabled: false,
+    mfaVerifiedAt: null,
+    ...overrides,
+  });
+}
+
+describe("evaluateGate — existing behavior", () => {
+  it("passes cron routes through", () => {
+    expect(gate({ pathname: "/api/cron/sync-transactions", isLoggedIn: false }))
+      .toEqual({ type: "next" });
+  });
+
+  it("passes telegram routes through", () => {
+    expect(gate({ pathname: "/api/telegram/webhook", isLoggedIn: false }))
+      .toEqual({ type: "next" });
+  });
+
+  it("redirects unauthenticated dashboard hits to /auth/signin", () => {
+    expect(gate({ isLoggedIn: false })).toEqual({
+      type: "redirect",
+      path: "/auth/signin",
+    });
+  });
+
+  it("returns 401 JSON for unauthenticated /api/admin/*", () => {
+    expect(gate({ pathname: "/api/admin/users", isLoggedIn: false })).toEqual({
+      type: "json",
+      status: 401,
+      body: { error: "Unauthorized" },
+    });
+  });
+
+  it("redirects logged-in users away from /auth/signin", () => {
+    expect(gate({ pathname: "/auth/signin" })).toEqual({
+      type: "redirect",
+      path: "/dashboard",
+    });
+  });
+});
+
+describe("evaluateGate — MFA enforcement", () => {
+  it("redirects dashboard to /auth/mfa when MFA enabled but unverified", () => {
+    expect(gate({ mfaEnabled: true, mfaVerifiedAt: null })).toEqual({
+      type: "redirect",
+      path: "/auth/mfa",
+    });
+  });
+
+  it("redirects profile to /auth/mfa when MFA enabled but unverified", () => {
+    expect(
+      gate({ pathname: "/profile", mfaEnabled: true, mfaVerifiedAt: null }),
+    ).toEqual({ type: "redirect", path: "/auth/mfa" });
+  });
+
+  it("returns 401 JSON for /api/admin/* when MFA enabled but unverified", () => {
+    expect(
+      gate({
+        pathname: "/api/admin/users",
+        mfaEnabled: true,
+        mfaVerifiedAt: null,
+      }),
+    ).toEqual({
+      type: "json",
+      status: 401,
+      body: { error: "MFA required" },
+    });
+  });
+
+  it("allows /auth/mfa itself through so the user can verify", () => {
+    expect(
+      gate({ pathname: "/auth/mfa", mfaEnabled: true, mfaVerifiedAt: null }),
+    ).toEqual({ type: "next" });
+  });
+
+  it("does NOT redirect away from /auth/mfa for logged-in users", () => {
+    // existing /auth/* redirect rule must not bounce the MFA page back to /dashboard
+    expect(gate({ pathname: "/auth/mfa", mfaEnabled: false })).toEqual({
+      type: "next",
+    });
+  });
+
+  it("passes when MFA is verified", () => {
+    expect(gate({ mfaEnabled: true, mfaVerifiedAt: new Date() })).toEqual({
+      type: "next",
+    });
+  });
+
+  it("passes when MFA is not enabled", () => {
+    expect(gate({ mfaEnabled: false, mfaVerifiedAt: null })).toEqual({
+      type: "next",
+    });
+  });
+
+  it("treats string-form mfaVerifiedAt (JSON-serialized) as verified", () => {
+    expect(
+      gate({ mfaEnabled: true, mfaVerifiedAt: new Date().toISOString() }),
+    ).toEqual({ type: "next" });
+  });
+});

--- a/src/app/api/mfa/verify/route.ts
+++ b/src/app/api/mfa/verify/route.ts
@@ -3,6 +3,34 @@ import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { confirmMfaEnrollment, verifyMfaCode, hasMfaEnabled } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
 import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
+import { db } from "@/db";
+import { sessions } from "@/db/schema";
+import { eq } from "drizzle-orm";
+
+// NextAuth's session cookie names (insecure for HTTP, __Secure- prefix on HTTPS).
+const SESSION_COOKIE_NAMES = [
+  "__Secure-authjs.session-token",
+  "authjs.session-token",
+  "__Secure-next-auth.session-token",
+  "next-auth.session-token",
+];
+
+function readSessionToken(request: NextRequest): string | null {
+  for (const name of SESSION_COOKIE_NAMES) {
+    const v = request.cookies.get(name)?.value;
+    if (v) return v;
+  }
+  return null;
+}
+
+async function markSessionMfaVerified(request: NextRequest): Promise<void> {
+  const token = readSessionToken(request);
+  if (!token) return;
+  await db
+    .update(sessions)
+    .set({ mfaVerifiedAt: new Date() })
+    .where(eq(sessions.sessionToken, token));
+}
 
 async function _POST(request: NextRequest) {
   const guard = await requireUser();
@@ -53,6 +81,7 @@ async function _POST(request: NextRequest) {
     }
 
     await resetAttempts(rateLimitKey);
+    await markSessionMfaVerified(request);
     await audit({
       userId: session.user.id,
       action: "auth.mfa_verified",
@@ -79,6 +108,7 @@ async function _POST(request: NextRequest) {
   }
 
   await resetAttempts(rateLimitKey);
+  await markSessionMfaVerified(request);
   await audit({
     userId: session.user.id,
     action: "auth.mfa_verified",

--- a/src/app/auth/mfa/page.tsx
+++ b/src/app/auth/mfa/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { ShieldCheck } from "lucide-react";
+
+export default function MfaChallengePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [code, setCode] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/mfa/verify", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code: code.trim() }),
+      });
+      if (res.status === 429) {
+        setError("Too many attempts. Try again later.");
+        return;
+      }
+      if (!res.ok) {
+        setError("Invalid code. Try again.");
+        return;
+      }
+      const callbackUrl = searchParams.get("callbackUrl") || "/dashboard";
+      router.replace(callbackUrl);
+      router.refresh();
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-background relative overflow-hidden">
+      <div className="max-w-md w-full p-8 mx-4 bg-background-card-auth rounded-2xl border border-border shadow-sm relative animate-scale-in">
+        <div className="text-center mb-8">
+          <ShieldCheck className="w-12 h-12 text-foreground-muted mx-auto mb-4" />
+          <h1 className="text-2xl font-bold">Two-factor authentication</h1>
+          <p className="text-foreground-muted mt-2">
+            Enter the 6-digit code from your authenticator app, or a recovery code.
+          </p>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div>
+            <label
+              htmlFor="code"
+              className="block text-sm font-medium text-foreground-muted mb-1"
+            >
+              Code
+            </label>
+            <input
+              id="code"
+              type="text"
+              inputMode="text"
+              autoComplete="one-time-code"
+              autoFocus
+              required
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              placeholder="123456"
+              className="w-full px-4 py-2 border border-border rounded-xl bg-background text-foreground placeholder:text-foreground-tertiary focus:ring-2 focus:ring-accent focus:border-accent outline-none transition-all duration-150 tracking-widest text-center text-lg"
+            />
+          </div>
+
+          {error && (
+            <p className="text-sm text-red-600" role="alert">
+              {error}
+            </p>
+          )}
+
+          <button
+            type="submit"
+            disabled={loading || code.trim().length < 6}
+            className="w-full py-2 px-4 bg-accent text-white rounded-xl hover:bg-accent-hover disabled:opacity-50 disabled:cursor-not-allowed font-medium transition-all duration-150 active:scale-95"
+          >
+            {loading ? "Verifying..." : "Verify"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/auth/mfa/page.tsx
+++ b/src/app/auth/mfa/page.tsx
@@ -1,10 +1,18 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { ShieldCheck } from "lucide-react";
 
 export default function MfaChallengePage() {
+  return (
+    <Suspense fallback={null}>
+      <MfaChallengeForm />
+    </Suspense>
+  );
+}
+
+function MfaChallengeForm() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [code, setCode] = useState("");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -93,6 +93,7 @@ export const sessions = pgTable(
     sessionToken: text("session_token").notNull().unique(),
     userId: uuid("user_id").notNull(),
     expires: timestamp("expires", { mode: "date" }).notNull(),
+    mfaVerifiedAt: timestamp("mfa_verified_at", { mode: "date" }),
   },
   (table) => [
     index("idx_sessions_user_id").on(table.userId),

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -200,6 +200,7 @@ export const authConfig: NextAuthConfig = {
           email: user.email,
           name: user.name,
           emailVerified: user.emailVerified,
+          mfaVerifiedAt: session.mfaVerifiedAt,
         },
       };
     },
@@ -274,6 +275,9 @@ export const authConfig: NextAuthConfig = {
         (session.user as unknown as Record<string, unknown>).role = currentUser.role;
         (session.user as unknown as Record<string, unknown>).mfaEnabled = currentUser.mfaEnabled;
       }
+
+      (session.user as unknown as Record<string, unknown>).mfaVerifiedAt =
+        (user as { mfaVerifiedAt?: Date | null }).mfaVerifiedAt ?? null;
 
       return session;
     },

--- a/src/lib/middleware-gate.ts
+++ b/src/lib/middleware-gate.ts
@@ -1,0 +1,52 @@
+export type GateAction =
+  | { type: "next" }
+  | { type: "redirect"; path: string }
+  | { type: "json"; status: number; body: { error: string } };
+
+export interface GateInput {
+  pathname: string;
+  isLoggedIn: boolean;
+  mfaEnabled: boolean;
+  mfaVerifiedAt: Date | string | null | undefined;
+}
+
+export function evaluateGate({
+  pathname,
+  isLoggedIn,
+  mfaEnabled,
+  mfaVerifiedAt,
+}: GateInput): GateAction {
+  const isAuthPage = pathname.startsWith("/auth");
+  const isMfaPage = pathname.startsWith("/auth/mfa");
+  const isDashboardPage = pathname.startsWith("/dashboard");
+  const isProfilePage = pathname.startsWith("/profile");
+  const isAdminRoute = pathname.startsWith("/api/admin");
+  const isCronRoute = pathname.startsWith("/api/cron");
+  const isTelegramRoute = pathname.startsWith("/api/telegram");
+
+  if (isCronRoute || isTelegramRoute) {
+    return { type: "next" };
+  }
+
+  if (isAuthPage && isLoggedIn && !isMfaPage) {
+    return { type: "redirect", path: "/dashboard" };
+  }
+
+  if ((isDashboardPage || isProfilePage || isAdminRoute) && !isLoggedIn) {
+    if (isAdminRoute) {
+      return { type: "json", status: 401, body: { error: "Unauthorized" } };
+    }
+    return { type: "redirect", path: "/auth/signin" };
+  }
+
+  if (isLoggedIn && mfaEnabled && !mfaVerifiedAt && !isMfaPage) {
+    if (isAdminRoute) {
+      return { type: "json", status: 401, body: { error: "MFA required" } };
+    }
+    if (isDashboardPage || isProfilePage) {
+      return { type: "redirect", path: "/auth/mfa" };
+    }
+  }
+
+  return { type: "next" };
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,6 +9,7 @@ const { auth } = NextAuth(authConfig);
 export default auth((req) => {
   const isLoggedIn = !!req.auth;
   const isAuthPage = req.nextUrl.pathname.startsWith("/auth");
+  const isMfaPage = req.nextUrl.pathname.startsWith("/auth/mfa");
   const isDashboardPage = req.nextUrl.pathname.startsWith("/dashboard");
   const isProfilePage = req.nextUrl.pathname.startsWith("/profile");
   const isAdminRoute = req.nextUrl.pathname.startsWith("/api/admin");
@@ -20,8 +21,9 @@ export default auth((req) => {
     return NextResponse.next();
   }
 
-  // Redirect logged-in users away from auth pages to dashboard
-  if (isAuthPage && isLoggedIn) {
+  // Redirect logged-in users away from auth pages to dashboard.
+  // Exception: /auth/mfa is the MFA challenge page — keep it reachable.
+  if (isAuthPage && isLoggedIn && !isMfaPage) {
     return NextResponse.redirect(new URL("/dashboard", req.nextUrl));
   }
 
@@ -31,6 +33,22 @@ export default auth((req) => {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
     return NextResponse.redirect(new URL("/auth/signin", req.nextUrl));
+  }
+
+  // MFA enforcement: logged in with MFA enabled but session not yet verified.
+  if (isLoggedIn) {
+    const user = req.auth?.user as
+      | { mfaEnabled?: boolean; mfaVerifiedAt?: Date | string | null }
+      | undefined;
+    const mfaRequired = !!user?.mfaEnabled && !user?.mfaVerifiedAt;
+    if (mfaRequired && !isMfaPage) {
+      if (isAdminRoute) {
+        return NextResponse.json({ error: "MFA required" }, { status: 401 });
+      }
+      if (isDashboardPage || isProfilePage) {
+        return NextResponse.redirect(new URL("/auth/mfa", req.nextUrl));
+      }
+    }
   }
 
   return NextResponse.next();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,57 +1,32 @@
 import NextAuth from "next-auth";
 import { authConfig } from "@/lib/auth.config";
 import { NextResponse } from "next/server";
+import { evaluateGate } from "@/lib/middleware-gate";
 
 // Use the lightweight auth config (no Email provider / nodemailer)
 // so middleware can run in the Edge Runtime.
 const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
-  const isLoggedIn = !!req.auth;
-  const isAuthPage = req.nextUrl.pathname.startsWith("/auth");
-  const isMfaPage = req.nextUrl.pathname.startsWith("/auth/mfa");
-  const isDashboardPage = req.nextUrl.pathname.startsWith("/dashboard");
-  const isProfilePage = req.nextUrl.pathname.startsWith("/profile");
-  const isAdminRoute = req.nextUrl.pathname.startsWith("/api/admin");
-  const isCronRoute = req.nextUrl.pathname.startsWith("/api/cron");
-  const isTelegramRoute = req.nextUrl.pathname.startsWith("/api/telegram");
+  const user = req.auth?.user as
+    | { mfaEnabled?: boolean; mfaVerifiedAt?: Date | string | null }
+    | undefined;
 
-  // Allow cron and telegram webhook routes through (have their own auth)
-  if (isCronRoute || isTelegramRoute) {
-    return NextResponse.next();
+  const action = evaluateGate({
+    pathname: req.nextUrl.pathname,
+    isLoggedIn: !!req.auth,
+    mfaEnabled: !!user?.mfaEnabled,
+    mfaVerifiedAt: user?.mfaVerifiedAt ?? null,
+  });
+
+  switch (action.type) {
+    case "next":
+      return NextResponse.next();
+    case "redirect":
+      return NextResponse.redirect(new URL(action.path, req.nextUrl));
+    case "json":
+      return NextResponse.json(action.body, { status: action.status });
   }
-
-  // Redirect logged-in users away from auth pages to dashboard.
-  // Exception: /auth/mfa is the MFA challenge page — keep it reachable.
-  if (isAuthPage && isLoggedIn && !isMfaPage) {
-    return NextResponse.redirect(new URL("/dashboard", req.nextUrl));
-  }
-
-  // Protect dashboard, profile, and admin routes
-  if ((isDashboardPage || isProfilePage || isAdminRoute) && !isLoggedIn) {
-    if (isAdminRoute) {
-      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-    }
-    return NextResponse.redirect(new URL("/auth/signin", req.nextUrl));
-  }
-
-  // MFA enforcement: logged in with MFA enabled but session not yet verified.
-  if (isLoggedIn) {
-    const user = req.auth?.user as
-      | { mfaEnabled?: boolean; mfaVerifiedAt?: Date | string | null }
-      | undefined;
-    const mfaRequired = !!user?.mfaEnabled && !user?.mfaVerifiedAt;
-    if (mfaRequired && !isMfaPage) {
-      if (isAdminRoute) {
-        return NextResponse.json({ error: "MFA required" }, { status: 401 });
-      }
-      if (isDashboardPage || isProfilePage) {
-        return NextResponse.redirect(new URL("/auth/mfa", req.nextUrl));
-      }
-    }
-  }
-
-  return NextResponse.next();
 });
 
 export const config = {

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -5,6 +5,7 @@ declare module "next-auth" {
   interface User {
     role?: UserRole;
     mfaEnabled?: boolean;
+    mfaVerifiedAt?: Date | null;
   }
 
   interface Session {
@@ -14,6 +15,7 @@ declare module "next-auth" {
       name?: string | null;
       role?: UserRole;
       mfaEnabled?: boolean;
+      mfaVerifiedAt?: Date | null;
     };
   }
 }


### PR DESCRIPTION
## Summary

Closes #73 — Enforce MFA verification after login when `mfaEnabled=true`.

A user with MFA enabled who completed Google OAuth or an email magic link
previously gained full dashboard/profile/admin access without ever entering
a TOTP code. This PR adds a per-session `mfa_verified_at` timestamp, marks
it on a successful `/api/mfa/verify` POST, and gates the middleware on it.

## Changes

- **Schema** (`src/db/schema.ts`): add nullable `sessions.mfa_verified_at`.
- **Adapter** (`src/lib/auth.config.ts`): `getSessionAndUser` returns the
  session-row `mfaVerifiedAt`; session callback exposes it as
  `session.user.mfaVerifiedAt`.
- **Verify route** (`src/app/api/mfa/verify/route.ts`): on successful TOTP
  or recovery-code verify, read the NextAuth session-token cookie and
  `UPDATE sessions SET mfa_verified_at = NOW() WHERE session_token = …`.
  Handles both cookie variants (`authjs.session-token` and `__Secure-`).
- **Middleware gate** (`src/lib/middleware-gate.ts` + `src/middleware.ts`):
  extracted into a pure function. If `mfaEnabled && !mfaVerifiedAt`,
  pages redirect to `/auth/mfa`, `/api/admin/*` returns 401. Cron and
  Telegram routes remain excluded.
- **Challenge page** (`src/app/auth/mfa/page.tsx`): minimal form posting to
  `/api/mfa/verify`.
- **Types** (`src/types/next-auth.d.ts`): add `mfaVerifiedAt` to `User` /
  `Session.user`.

## Tests

- `src/__tests__/middleware-gate.test.ts` — 13 tests covering existing
  routing behavior + MFA-required redirects/401s, plus `/auth/mfa`
  reachability.
- `src/__tests__/mfa-verify-route.test.ts` — 6 tests asserting `UPDATE`
  fires on success, never fires on failure / rate-limit / missing cookie,
  and handles the `__Secure-` cookie variant.

All 137 tests pass. `npm run build` succeeds.

## Schema migration

Project uses declarative `db:push` (no `drizzle/` migrations directory).
The new column is nullable, so it is safe to apply before this PR merges.
**Already pushed to Neon prod** in the same session.

## Verification checklist

- [x] Schema change applied to Neon (`npm run db:push`).
- [x] Logged-in user with `mfaEnabled=true` and null `mfaVerifiedAt` is
      blocked from `/dashboard`, `/profile`, `/api/admin/*` (unit tested
      via `evaluateGate`).
- [x] Same user is allowed after a successful POST `/api/mfa/verify`
      (unit tested — `UPDATE` fires).
- [x] `mfaVerifiedAt` is null by default after `createSession` (schema
      default).
- [ ] Manual: enable MFA, log out, sign in via Google OAuth → expect
      redirect to `/auth/mfa`.
- [ ] Manual: same via email magic link → expect redirect.
- [ ] Manual: enter code → redirected back to `/dashboard`.

## What was NOT changed

- `/api/sync/*` and `/api/data/*` are NOT in the middleware matcher today
  and were left out of scope here. If those should be gated too, that's a
  follow-up that requires extending the matcher.
- `users.mfaEnabled` boolean (set by `confirmMfaEnrollment` /
  `disableMfa`) remains the source of truth for `session.user.mfaEnabled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
