### PR TITLE
fix(security): require verification for email changes (#74)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^20",
+        "@types/nodemailer": "^8.0.0",
         "@types/papaparse": "^5.5.2",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -3118,6 +3119,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-8.0.0.tgz",
+      "integrity": "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/papaparse": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^20",
+    "@types/nodemailer": "^8.0.0",
     "@types/papaparse": "^5.5.2",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/src/__tests__/profile-email-change.test.ts
+++ b/src/__tests__/profile-email-change.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ─── Mocks ───────────────────────────────────────────────────────────────────
+const insertValues = vi.fn();
+const updateWhere = vi.fn();
+const updateSet = vi.fn(() => ({ where: updateWhere, returning: vi.fn() }));
+const deleteWhere = vi.fn();
+const selectLimit = vi.fn();
+const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: vi.fn(() => ({ values: insertValues })),
+    update: vi.fn(() => ({ set: updateSet })),
+    delete: vi.fn(() => ({ where: deleteWhere })),
+    select: vi.fn(() => ({ from: selectFrom })),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/scd2", () => ({
+  updateUserProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/email", () => ({
+  sendEmailChangeConfirmation: vi.fn().mockResolvedValue(undefined),
+  sendEmailChangeNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  audit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+  recordFailure: vi.fn().mockResolvedValue({ remaining: 4 }),
+}));
+
+import { auth } from "@/lib/auth";
+import { updateUserProfile } from "@/lib/scd2";
+import {
+  sendEmailChangeConfirmation,
+  sendEmailChangeNotification,
+} from "@/lib/email";
+import { audit } from "@/lib/audit";
+import { checkRateLimit } from "@/lib/rate-limit";
+import { db } from "@/db";
+import { PUT } from "@/app/api/profile/route";
+import { GET as CONFIRM } from "@/app/api/profile/confirm-email/route";
+import { GET as REVOKE } from "@/app/api/profile/revoke-email-change/route";
+
+const mockedAuth = vi.mocked(auth);
+const mockedUpdateProfile = vi.mocked(updateUserProfile);
+const mockedSendConfirm = vi.mocked(sendEmailChangeConfirmation);
+const mockedSendNotify = vi.mocked(sendEmailChangeNotification);
+const mockedAudit = vi.mocked(audit);
+const mockedCheckRateLimit = vi.mocked(checkRateLimit);
+const mockedDbInsert = vi.mocked(db.insert);
+const mockedDbUpdate = vi.mocked(db.update);
+const mockedDbDelete = vi.mocked(db.delete);
+
+function loggedIn(email = "old@example.com") {
+  mockedAuth.mockResolvedValue({
+    user: { id: "user-1", email, name: "Test" },
+    expires: "9999-12-31",
+  } as never);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  insertValues.mockResolvedValue(undefined);
+  updateWhere.mockResolvedValue(undefined);
+  updateSet.mockReturnValue({ where: updateWhere, returning: vi.fn().mockResolvedValue([{ id: "ec-1" }]) });
+  deleteWhere.mockResolvedValue(undefined);
+  selectLimit.mockResolvedValue([]);
+  selectFrom.mockReturnValue({ where: selectWhere });
+  selectWhere.mockReturnValue({ limit: selectLimit });
+  mockedDbInsert.mockReturnValue({ values: insertValues } as never);
+  mockedDbUpdate.mockReturnValue({ set: updateSet } as never);
+  mockedDbDelete.mockReturnValue({ where: deleteWhere } as never);
+  mockedCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 5 });
+});
+
+function putReq(body: Record<string, unknown>) {
+  return new NextRequest("https://app.example.com/api/profile", {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PUT /api/profile — email change request flow", () => {
+  it("requires auth", async () => {
+    mockedAuth.mockResolvedValue(null as never);
+    const res = await PUT(putReq({ email: "new@example.com" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("creates pending email-change row + sends both emails + audits + does NOT call updateUserProfile", async () => {
+    loggedIn();
+    const res = await PUT(putReq({ email: "new@example.com" }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.pendingEmailChange).toBe(true);
+
+    expect(mockedDbInsert).toHaveBeenCalledTimes(1);
+    expect(insertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: expect.any(String),
+        revokeToken: expect.any(String),
+        expires: expect.any(Date),
+      }),
+    );
+
+    expect(mockedSendConfirm).toHaveBeenCalledWith(
+      "new@example.com",
+      expect.stringContaining("/api/profile/confirm-email?token="),
+    );
+    expect(mockedSendNotify).toHaveBeenCalledWith(
+      "old@example.com",
+      "new@example.com",
+      expect.stringContaining("/api/profile/revoke-email-change?token="),
+    );
+
+    expect(mockedAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "profile.email_change_requested" }),
+    );
+
+    // The user record itself must NOT be touched for an email change.
+    expect(mockedUpdateProfile).not.toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ email: expect.any(String) }),
+    );
+  });
+
+  it("name-only update goes directly through updateUserProfile (no pending row)", async () => {
+    loggedIn();
+    mockedUpdateProfile.mockResolvedValueOnce({
+      userId: "user-1",
+      email: "old@example.com",
+      name: "New Name",
+    } as never);
+    const res = await PUT(putReq({ name: "New Name" }));
+    expect(res.status).toBe(200);
+    expect(mockedDbInsert).not.toHaveBeenCalled();
+    expect(mockedSendConfirm).not.toHaveBeenCalled();
+    expect(mockedUpdateProfile).toHaveBeenCalledWith("user-1", { name: "New Name" });
+  });
+
+  it("same-email is not treated as a change", async () => {
+    loggedIn("same@example.com");
+    mockedUpdateProfile.mockResolvedValueOnce({
+      userId: "user-1",
+      email: "same@example.com",
+      name: "Test",
+    } as never);
+    const res = await PUT(putReq({ email: "same@example.com", name: "Test" }));
+    expect(res.status).toBe(200);
+    expect(mockedDbInsert).not.toHaveBeenCalled();
+    expect(mockedSendConfirm).not.toHaveBeenCalled();
+  });
+
+  it("returns 429 when rate limited and does NOT send mail or insert a token", async () => {
+    loggedIn();
+    mockedCheckRateLimit.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: 60_000,
+    });
+    const res = await PUT(putReq({ email: "new@example.com" }));
+    expect(res.status).toBe(429);
+    expect(res.headers.get("Retry-After")).toBe("60");
+    expect(mockedDbInsert).not.toHaveBeenCalled();
+    expect(mockedSendConfirm).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid email format", async () => {
+    loggedIn();
+    const res = await PUT(putReq({ email: "not-an-email" }));
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /api/profile/confirm-email", () => {
+  function confirmReq(token: string | null) {
+    const url = token
+      ? `https://app.example.com/api/profile/confirm-email?token=${token}`
+      : "https://app.example.com/api/profile/confirm-email";
+    return new NextRequest(url);
+  }
+
+  it("400 when no token", async () => {
+    const res = await CONFIRM(confirmReq(null));
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when token not found", async () => {
+    selectLimit.mockResolvedValueOnce([]);
+    const res = await CONFIRM(confirmReq("nope"));
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when token already used", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() + 60_000),
+        usedAt: new Date(),
+        cancelledAt: null,
+      },
+    ]);
+    const res = await CONFIRM(confirmReq("t"));
+    expect(res.status).toBe(400);
+    expect(mockedUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it("400 when token cancelled", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() + 60_000),
+        usedAt: null,
+        cancelledAt: new Date(),
+      },
+    ]);
+    const res = await CONFIRM(confirmReq("t"));
+    expect(res.status).toBe(400);
+    expect(mockedUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it("400 when token expired", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() - 60_000),
+        usedAt: null,
+        cancelledAt: null,
+      },
+    ]);
+    const res = await CONFIRM(confirmReq("t"));
+    expect(res.status).toBe(400);
+    expect(mockedUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it("on success: marks used, updates profile with emailVerified=now, deletes all sessions, audits", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() + 60_000),
+        usedAt: null,
+        cancelledAt: null,
+      },
+    ]);
+    updateSet.mockReturnValueOnce({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: "ec-1" }]) })),
+    });
+    mockedUpdateProfile.mockResolvedValueOnce({} as never);
+
+    const res = await CONFIRM(confirmReq("t"));
+    expect(res.status).toBe(200);
+
+    expect(mockedUpdateProfile).toHaveBeenCalledWith("user-1", {
+      email: "new@example.com",
+      emailVerified: expect.any(Date),
+    });
+    expect(mockedDbDelete).toHaveBeenCalledTimes(1);
+    expect(mockedAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "profile.email_change_completed" }),
+    );
+  });
+
+  it("400 if concurrent request already consumed the token (atomic mark-used fails)", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() + 60_000),
+        usedAt: null,
+        cancelledAt: null,
+      },
+    ]);
+    updateSet.mockReturnValueOnce({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([]) })),
+    });
+
+    const res = await CONFIRM(confirmReq("t"));
+    expect(res.status).toBe(400);
+    expect(mockedUpdateProfile).not.toHaveBeenCalled();
+    expect(mockedDbDelete).not.toHaveBeenCalled();
+  });
+});
+
+describe("GET /api/profile/revoke-email-change", () => {
+  function revokeReq(token: string | null) {
+    const url = token
+      ? `https://app.example.com/api/profile/revoke-email-change?token=${token}`
+      : "https://app.example.com/api/profile/revoke-email-change";
+    return new NextRequest(url);
+  }
+
+  it("400 when no token", async () => {
+    const res = await REVOKE(revokeReq(null));
+    expect(res.status).toBe(400);
+  });
+
+  it("400 when already confirmed", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() + 60_000),
+        usedAt: new Date(),
+        cancelledAt: null,
+      },
+    ]);
+    const res = await REVOKE(revokeReq("r"));
+    expect(res.status).toBe(400);
+  });
+
+  it("marks cancelledAt + audits on valid revoke", async () => {
+    selectLimit.mockResolvedValueOnce([
+      {
+        id: "ec-1",
+        userId: "user-1",
+        newEmail: "new@example.com",
+        token: "t",
+        revokeToken: "r",
+        expires: new Date(Date.now() + 60_000),
+        usedAt: null,
+        cancelledAt: null,
+      },
+    ]);
+    updateSet.mockReturnValueOnce({
+      where: vi.fn(() => ({ returning: vi.fn().mockResolvedValue([{ id: "ec-1" }]) })),
+    });
+
+    const res = await REVOKE(revokeReq("r"));
+    expect(res.status).toBe(200);
+    expect(mockedAudit).toHaveBeenCalledWith(
+      expect.objectContaining({ action: "profile.email_change_cancelled" }),
+    );
+  });
+});

--- a/src/__tests__/scd2-email-verified.test.ts
+++ b/src/__tests__/scd2-email-verified.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const selectLimit = vi.fn();
+const selectWhere = vi.fn(() => ({ limit: selectLimit }));
+const selectFrom = vi.fn(() => ({ where: selectWhere }));
+
+const txUpdateWhere = vi.fn().mockResolvedValue(undefined);
+const txUpdateSet = vi.fn(() => ({ where: txUpdateWhere }));
+const txInsertReturning = vi.fn();
+const txInsertValues = vi.fn(() => ({ returning: txInsertReturning }));
+
+const txObj = {
+  update: vi.fn(() => ({ set: txUpdateSet })),
+  insert: vi.fn(() => ({ values: txInsertValues })),
+};
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn(() => ({ from: selectFrom })),
+    transaction: vi.fn(async (cb: (tx: typeof txObj) => Promise<unknown>) => cb(txObj)),
+  },
+}));
+
+import { updateUserProfile } from "@/lib/scd2";
+
+const CURRENT_VERIFIED = new Date("2026-01-01T00:00:00Z");
+const CURRENT_ROW = {
+  id: "row-1",
+  userId: "user-1",
+  email: "old@example.com",
+  name: "Old Name",
+  emailVerified: CURRENT_VERIFIED,
+  validFrom: new Date("2026-01-01"),
+  isCurrent: true,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  selectLimit.mockResolvedValue([CURRENT_ROW]);
+  selectFrom.mockReturnValue({ where: selectWhere });
+  selectWhere.mockReturnValue({ limit: selectLimit });
+  txInsertReturning.mockResolvedValue([{ id: "row-2", userId: "user-1" }]);
+});
+
+describe("updateUserProfile — emailVerified handling on email swap", () => {
+  it("resets emailVerified to null when email changes without explicit override", async () => {
+    await updateUserProfile("user-1", { email: "new@example.com" });
+    expect(txInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "new@example.com",
+        emailVerified: null,
+      }),
+    );
+  });
+
+  it("honors explicit emailVerified when provided alongside email change", async () => {
+    const ts = new Date("2026-05-20T12:00:00Z");
+    await updateUserProfile("user-1", {
+      email: "new@example.com",
+      emailVerified: ts,
+    });
+    expect(txInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "new@example.com",
+        emailVerified: ts,
+      }),
+    );
+  });
+
+  it("preserves emailVerified on a name-only update", async () => {
+    await updateUserProfile("user-1", { name: "New Name" });
+    expect(txInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "old@example.com",
+        name: "New Name",
+        emailVerified: CURRENT_VERIFIED,
+      }),
+    );
+  });
+
+  it("preserves emailVerified when email is passed but unchanged", async () => {
+    await updateUserProfile("user-1", { email: "old@example.com" });
+    expect(txInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "old@example.com",
+        emailVerified: CURRENT_VERIFIED,
+      }),
+    );
+  });
+
+  it("honors explicit null emailVerified override", async () => {
+    await updateUserProfile("user-1", { emailVerified: null });
+    expect(txInsertValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        emailVerified: null,
+      }),
+    );
+  });
+});

--- a/src/app/api/profile/confirm-email/route.ts
+++ b/src/app/api/profile/confirm-email/route.ts
@@ -1,0 +1,101 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, isNull } from "drizzle-orm";
+import { withErrorHandling } from "@/lib/api-helpers";
+import { updateUserProfile } from "@/lib/scd2";
+import { db } from "@/db";
+import { emailChangeTokens, sessions } from "@/db/schema";
+import { audit } from "@/lib/audit";
+
+function errorPage(message: string): NextResponse {
+  const html = `<!doctype html><html><head><title>Email Change</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;line-height:1.5}</style>
+</head><body><h1>Email change failed</h1><p>${message}</p>
+<p><a href="/dashboard">Return to dashboard</a></p></body></html>`;
+  return new NextResponse(html, {
+    status: 400,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+function successPage(newEmail: string): NextResponse {
+  const html = `<!doctype html><html><head><title>Email Change</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;line-height:1.5}</style>
+</head><body><h1>Email changed</h1>
+<p>Your account email is now <strong>${newEmail}</strong>. For security, all other sessions have been signed out.</p>
+<p><a href="/dashboard">Return to dashboard</a></p></body></html>`;
+  return new NextResponse(html, {
+    status: 200,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+async function _GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token");
+  if (!token) {
+    return errorPage("Missing token.");
+  }
+
+  const [row] = await db
+    .select()
+    .from(emailChangeTokens)
+    .where(eq(emailChangeTokens.token, token))
+    .limit(1);
+
+  if (!row) {
+    return errorPage("Invalid or expired token.");
+  }
+
+  if (row.usedAt) {
+    return errorPage("This confirmation link has already been used.");
+  }
+
+  if (row.cancelledAt) {
+    return errorPage("This email change was cancelled.");
+  }
+
+  if (row.expires.getTime() < Date.now()) {
+    return errorPage("This confirmation link has expired.");
+  }
+
+  // Atomically mark the token used so a concurrent request cannot
+  // double-spend it.
+  const [marked] = await db
+    .update(emailChangeTokens)
+    .set({ usedAt: new Date() })
+    .where(
+      and(
+        eq(emailChangeTokens.id, row.id),
+        isNull(emailChangeTokens.usedAt),
+        isNull(emailChangeTokens.cancelledAt)
+      )
+    )
+    .returning();
+
+  if (!marked) {
+    return errorPage("This confirmation link has already been used.");
+  }
+
+  await updateUserProfile(row.userId, {
+    email: row.newEmail,
+    emailVerified: new Date(),
+  });
+
+  // Sign out all sessions for this user. If an attacker initiated the
+  // change from a hijacked session, this cuts them off immediately.
+  await db.delete(sessions).where(eq(sessions.userId, row.userId));
+
+  await audit({
+    userId: row.userId,
+    action: "profile.email_change_completed",
+    resource: "users",
+    resourceId: row.userId,
+    detail: { newEmail: row.newEmail },
+    request,
+  });
+
+  return successPage(row.newEmail);
+}
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/profile/revoke-email-change/route.ts
+++ b/src/app/api/profile/revoke-email-change/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq, and, isNull } from "drizzle-orm";
+import { withErrorHandling } from "@/lib/api-helpers";
+import { db } from "@/db";
+import { emailChangeTokens } from "@/db/schema";
+import { audit } from "@/lib/audit";
+
+function page(status: number, title: string, message: string): NextResponse {
+  const html = `<!doctype html><html><head><title>${title}</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<style>body{font-family:system-ui,sans-serif;max-width:480px;margin:4rem auto;padding:0 1rem;line-height:1.5}</style>
+</head><body><h1>${title}</h1><p>${message}</p>
+<p><a href="/dashboard">Return to dashboard</a></p></body></html>`;
+  return new NextResponse(html, {
+    status,
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+}
+
+async function _GET(request: NextRequest) {
+  const token = request.nextUrl.searchParams.get("token");
+  if (!token) {
+    return page(400, "Revoke failed", "Missing token.");
+  }
+
+  const [row] = await db
+    .select()
+    .from(emailChangeTokens)
+    .where(eq(emailChangeTokens.revokeToken, token))
+    .limit(1);
+
+  if (!row) {
+    return page(400, "Revoke failed", "Invalid token.");
+  }
+
+  if (row.usedAt) {
+    return page(
+      400,
+      "Cannot revoke",
+      "This email change has already been confirmed. Sign in and change your email back, or contact support."
+    );
+  }
+
+  if (row.cancelledAt) {
+    return page(200, "Already cancelled", "This email change was already cancelled.");
+  }
+
+  const [marked] = await db
+    .update(emailChangeTokens)
+    .set({ cancelledAt: new Date() })
+    .where(
+      and(
+        eq(emailChangeTokens.id, row.id),
+        isNull(emailChangeTokens.usedAt),
+        isNull(emailChangeTokens.cancelledAt)
+      )
+    )
+    .returning();
+
+  if (!marked) {
+    return page(400, "Revoke failed", "Could not cancel — the request was already processed.");
+  }
+
+  await audit({
+    userId: row.userId,
+    action: "profile.email_change_cancelled",
+    resource: "users",
+    resourceId: row.userId,
+    detail: { newEmail: row.newEmail },
+    request,
+  });
+
+  return page(
+    200,
+    "Email change cancelled",
+    "The pending email change has been cancelled. Your account email is unchanged."
+  );
+}
+
+export const GET = withErrorHandling(_GET);

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,6 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
+import { randomBytes } from "crypto";
 import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { updateUserProfile } from "@/lib/scd2";
+import { db } from "@/db";
+import { emailChangeTokens } from "@/db/schema";
+import {
+  sendEmailChangeConfirmation,
+  sendEmailChangeNotification,
+} from "@/lib/email";
+import { audit } from "@/lib/audit";
+import { checkRateLimit, recordFailure } from "@/lib/rate-limit";
+
+const TOKEN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+function getBaseUrl(request: NextRequest): string {
+  const env = process.env.NEXTAUTH_URL ?? process.env.NEXT_PUBLIC_APP_URL;
+  if (env) return env.replace(/\/$/, "");
+  return request.nextUrl.origin;
+}
 
 async function _GET() {
   const guard = await requireUser();
@@ -19,7 +36,7 @@ async function _GET() {
 async function _PUT(request: NextRequest) {
   const guard = await requireUser();
   if (guard instanceof NextResponse) return guard;
-  const { session } = guard;
+  const { session, userId } = guard;
 
   const body = await request.json();
   const { name, email } = body;
@@ -31,7 +48,6 @@ async function _PUT(request: NextRequest) {
     );
   }
 
-  // Validate email format if provided
   if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return NextResponse.json(
       { error: "Invalid email format" },
@@ -39,9 +55,75 @@ async function _PUT(request: NextRequest) {
     );
   }
 
-  const updated = await updateUserProfile(session.user.id, {
+  const emailIsChanging = !!email && email !== session.user.email;
+
+  if (emailIsChanging) {
+    const rateKey = `email_change:${userId}`;
+    const limit = await checkRateLimit(rateKey);
+    if (!limit.allowed) {
+      const retryAfter = Math.ceil((limit.retryAfterMs ?? 0) / 1000);
+      return NextResponse.json(
+        { error: "Too many email change attempts" },
+        { status: 429, headers: { "Retry-After": String(retryAfter) } }
+      );
+    }
+    await recordFailure(rateKey);
+
+    const token = randomBytes(32).toString("hex");
+    const revokeToken = randomBytes(32).toString("hex");
+    const expires = new Date(Date.now() + TOKEN_TTL_MS);
+
+    await db.insert(emailChangeTokens).values({
+      userId,
+      newEmail: email,
+      token,
+      revokeToken,
+      expires,
+    });
+
+    const base = getBaseUrl(request);
+    const confirmLink = `${base}/api/profile/confirm-email?token=${token}`;
+    const revokeLink = `${base}/api/profile/revoke-email-change?token=${revokeToken}`;
+
+    try {
+      await sendEmailChangeConfirmation(email, confirmLink);
+      if (session.user.email) {
+        await sendEmailChangeNotification(
+          session.user.email,
+          email,
+          revokeLink
+        );
+      }
+    } catch (err) {
+      console.error("[profile] Email send failed:", err);
+      return NextResponse.json(
+        { error: "Failed to send verification email" },
+        { status: 500 }
+      );
+    }
+
+    await audit({
+      userId,
+      action: "profile.email_change_requested",
+      resource: "users",
+      resourceId: userId,
+      detail: { newEmail: email },
+      request,
+    });
+
+    if (name) {
+      await updateUserProfile(userId, { name });
+    }
+
+    return NextResponse.json({
+      pendingEmailChange: true,
+      message:
+        "Confirmation email sent to the new address. Your email will not change until you confirm.",
+    });
+  }
+
+  const updated = await updateUserProfile(userId, {
     name: name ?? undefined,
-    email: email ?? undefined,
   });
 
   return NextResponse.json({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,6 +39,9 @@ export const auditActionEnum = pgEnum("audit_action", [
   "admin.role_change",
   "admin.user_deprovisioned",
   "admin.access_review",
+  "profile.email_change_requested",
+  "profile.email_change_completed",
+  "profile.email_change_cancelled",
 ]);
 
 // ─── Users (SCD2) ────────────────────────────────────────────────────────────
@@ -191,6 +194,27 @@ export const telegramConfigs = pgTable(
   },
   (table) => [
     index("idx_telegram_configs_user_id").on(table.userId),
+  ]
+);
+
+// ─── Email Change Tokens ─────────────────────────────────────────────────────
+export const emailChangeTokens = pgTable(
+  "email_change_tokens",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id").notNull(),
+    newEmail: text("new_email").notNull(),
+    token: text("token").notNull().unique(),
+    revokeToken: text("revoke_token").notNull().unique(),
+    expires: timestamp("expires", { mode: "date" }).notNull(),
+    usedAt: timestamp("used_at", { mode: "date" }),
+    cancelledAt: timestamp("cancelled_at", { mode: "date" }),
+    createdAt: timestamp("created_at", { mode: "date" }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("idx_email_change_tokens_token").on(table.token),
+    index("idx_email_change_tokens_revoke_token").on(table.revokeToken),
+    index("idx_email_change_tokens_user_id").on(table.userId),
   ]
 );
 

--- a/src/lib/audit.ts
+++ b/src/lib/audit.ts
@@ -25,7 +25,10 @@ export type AuditAction =
   | "telegram.link_failed"
   | "admin.role_change"
   | "admin.user_deprovisioned"
-  | "admin.access_review";
+  | "admin.access_review"
+  | "profile.email_change_requested"
+  | "profile.email_change_completed"
+  | "profile.email_change_cancelled";
 
 interface AuditEntry {
   userId?: string | null;

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,71 @@
+import nodemailer from "nodemailer";
+
+/**
+ * Thin nodemailer wrapper for app-level transactional email.
+ * NextAuth's Email provider handles magic-link login via its own internal
+ * transport; this module is for everything else (e.g. email-change
+ * verification and old-address notifications).
+ *
+ * Uses EMAIL_SERVER + EMAIL_FROM env vars (already configured for NextAuth).
+ */
+
+function getTransport() {
+  const server = process.env.EMAIL_SERVER;
+  if (!server) {
+    throw new Error("EMAIL_SERVER is not configured");
+  }
+  return nodemailer.createTransport(server);
+}
+
+function getFrom() {
+  const from = process.env.EMAIL_FROM;
+  if (!from) {
+    throw new Error("EMAIL_FROM is not configured");
+  }
+  return from;
+}
+
+export async function sendEmailChangeConfirmation(
+  newEmail: string,
+  confirmLink: string
+): Promise<void> {
+  const transport = getTransport();
+  await transport.sendMail({
+    to: newEmail,
+    from: getFrom(),
+    subject: "Confirm your new email address",
+    text: `A request was made to change your Really Personal Finance email to this address.
+
+Click the link below to confirm. The link expires in 1 hour.
+
+${confirmLink}
+
+If you didn't request this, ignore this email.`,
+    html: `<p>A request was made to change your Really Personal Finance email to this address.</p>
+<p><a href="${confirmLink}">Confirm new email address</a></p>
+<p>The link expires in 1 hour. If you didn't request this, ignore this email.</p>`,
+  });
+}
+
+export async function sendEmailChangeNotification(
+  oldEmail: string,
+  newEmail: string,
+  revokeLink: string
+): Promise<void> {
+  const transport = getTransport();
+  await transport.sendMail({
+    to: oldEmail,
+    from: getFrom(),
+    subject: "Email change requested on your account",
+    text: `Someone requested to change the email on your Really Personal Finance account from ${oldEmail} to ${newEmail}.
+
+If this was you, you can ignore this message — the change won't take effect until the new address is confirmed.
+
+If this WAS NOT you, click the link below immediately to cancel:
+
+${revokeLink}`,
+    html: `<p>Someone requested to change the email on your Really Personal Finance account from <strong>${oldEmail}</strong> to <strong>${newEmail}</strong>.</p>
+<p>If this was you, you can ignore this message — the change won't take effect until the new address is confirmed.</p>
+<p>If this <strong>was not</strong> you, <a href="${revokeLink}">click here to cancel</a> immediately.</p>`,
+  });
+}

--- a/src/lib/scd2.ts
+++ b/src/lib/scd2.ts
@@ -31,24 +31,32 @@ export async function updateUserProfile(
 
   // Wrap close + insert in a transaction for atomicity.
   // If either operation fails, both are rolled back.
+  // If the email is changing without an explicit emailVerified, reset to null.
+  // Defense-in-depth: prevents any future caller from silently swapping email
+  // while keeping the prior verification timestamp. The verified email-change
+  // flow passes `emailVerified: new Date()` explicitly after token confirmation.
+  const emailIsChanging =
+    updates.email !== undefined && updates.email !== current.email;
+  const resolvedEmailVerified =
+    updates.emailVerified !== undefined
+      ? updates.emailVerified
+      : emailIsChanging
+        ? null
+        : current.emailVerified;
+
   const [newVersion] = await db.transaction(async (tx) => {
-    // Close current row
     await tx
       .update(users)
       .set({ validTo: now, isCurrent: false })
       .where(eq(users.id, current.id));
 
-    // Insert new version
     return tx
       .insert(users)
       .values({
         userId: current.userId,
         email: updates.email ?? current.email,
         name: updates.name ?? current.name,
-        emailVerified:
-          updates.emailVerified !== undefined
-            ? updates.emailVerified
-            : current.emailVerified,
+        emailVerified: resolvedEmailVerified,
         validFrom: now,
         isCurrent: true,
       })


### PR DESCRIPTION
## Summary

Email changes now go through a two-step verify-by-link flow with old-address notification, atomic single-use tokens, and other-session wipe on confirm. Root-cause fix: `updateUserProfile` no longer preserves `emailVerified` when the email is swapped.

Closes #74.

## What changed

- **New table** `email_change_tokens(userId, newEmail, token, revokeToken, expires, usedAt, cancelledAt)`. Schema pushed via `db:push` (additive, no migrations dir).
- **`PUT /api/profile`**: if `email` is supplied and differs from the current address, the user row is NOT modified. A pending row is inserted, a confirmation link goes to the new address, and a notification (with revoke link) goes to the old address. Name-only updates continue to work as before. Rate-limited via `rateLimitAttempts` (`email_change:<userId>`).
- **`GET /api/profile/confirm-email?token=…`**: validates token (existence, not used, not cancelled, not expired), marks it used atomically (`WHERE usedAt IS NULL AND cancelledAt IS NULL`), updates the SCD2 row with `emailVerified = now`, and deletes all sessions for the user (cuts off a hijacked-session attacker).
- **`GET /api/profile/revoke-email-change?token=…`**: legitimate user clicks from the OLD inbox to cancel — marks `cancelledAt` atomically.
- **`updateUserProfile`**: when `email` is provided without an explicit `emailVerified`, the new SCD2 row gets `emailVerified=null`. Defense-in-depth so this regression cannot be reintroduced elsewhere.
- **New `src/lib/email.ts`**: thin nodemailer wrapper (`EMAIL_SERVER`/`EMAIL_FROM` already configured for NextAuth). Two helpers: `sendEmailChangeConfirmation`, `sendEmailChangeNotification`.
- **New audit actions**: `profile.email_change_requested`, `profile.email_change_completed`, `profile.email_change_cancelled`. Added to the enum + the audit type union.

## Tests

21 new unit tests (158 total green):

- PUT route: email change creates pending row + emails + audits, does NOT touch `users`; name-only update goes through; same-email is a no-op; 429 with `Retry-After` when rate-limited; rejects invalid format.
- Confirm route: 400 on missing/unknown/used/cancelled/expired token; on success updates profile + deletes sessions + audits; 400 on concurrent double-spend (atomic mark-used returns empty).
- Revoke route: 400 on missing token / already-confirmed; on success marks `cancelledAt` + audits.
- scd2: resets `emailVerified=null` on email change; honors explicit override; preserves on name-only / same-email / explicit-null cases.

## Test plan

- [x] `npm run build` passes (Turbopack, TypeScript)
- [x] `npx vitest run` — 158/158 pass
- [x] `db:push` applied to Neon (additive, nullable columns)
- [ ] Manual: PUT `/api/profile` with `{ email: new }` → check new inbox for confirm link, old inbox for revoke link
- [ ] Manual: click confirm link → users row updates, all other sessions invalidated
- [ ] Manual: PUT new email again from a logged-in attacker session, click revoke link from old inbox → users row unchanged, pending row marked cancelled
- [ ] Manual: expired token (>1h) returns 400

## What NOT to do (already handled)

- Do not call `updateUserProfile` directly for email changes — funnel through the verify flow. The scd2 default now also resists this.
- Do not auto-verify the new email without the user clicking the link — explicit `emailVerified: new Date()` is only set in the confirm handler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)