### PR TITLE
feat(security): baseline HTTP security headers

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,32 @@
 import type { NextConfig } from "next";
 
+const csp = [
+  "default-src 'self'",
+  "script-src 'self' 'unsafe-inline' https://cdn.plaid.com",
+  "connect-src 'self' https://*.plaid.com",
+  "frame-src https://cdn.plaid.com",
+  "img-src 'self' data: https://*.plaid.com",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  "base-uri 'self'",
+  "form-action 'self'",
+  "frame-ancestors 'none'",
+  "object-src 'none'",
+].join("; ");
+
+export const securityHeaders = [
+  { key: "Strict-Transport-Security", value: "max-age=63072000; includeSubDomains" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  { key: "Content-Security-Policy", value: csp },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
+  async headers() {
+    return [{ source: "/:path*", headers: securityHeaders }];
+  },
 };
 
 export default nextConfig;

--- a/src/__tests__/security-headers.test.ts
+++ b/src/__tests__/security-headers.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import nextConfig, { securityHeaders } from "../../next.config";
+
+function headerValue(key: string): string {
+  const h = securityHeaders.find((x) => x.key === key);
+  if (!h) throw new Error(`Header not found: ${key}`);
+  return h.value;
+}
+
+describe("security headers", () => {
+  it("declares every required header", () => {
+    const keys = securityHeaders.map((h) => h.key);
+    expect(keys).toEqual(
+      expect.arrayContaining([
+        "Strict-Transport-Security",
+        "X-Content-Type-Options",
+        "X-Frame-Options",
+        "Referrer-Policy",
+        "Permissions-Policy",
+        "Content-Security-Policy",
+      ])
+    );
+  });
+
+  it("HSTS has max-age and includeSubDomains but not preload", () => {
+    const v = headerValue("Strict-Transport-Security");
+    expect(v).toMatch(/max-age=\d+/);
+    expect(v).toContain("includeSubDomains");
+    expect(v).not.toContain("preload");
+  });
+
+  it("X-Frame-Options is DENY", () => {
+    expect(headerValue("X-Frame-Options")).toBe("DENY");
+  });
+
+  it("X-Content-Type-Options is nosniff", () => {
+    expect(headerValue("X-Content-Type-Options")).toBe("nosniff");
+  });
+
+  it("Referrer-Policy is strict-origin-when-cross-origin", () => {
+    expect(headerValue("Referrer-Policy")).toBe("strict-origin-when-cross-origin");
+  });
+
+  it("Permissions-Policy locks down camera, microphone, geolocation", () => {
+    const v = headerValue("Permissions-Policy");
+    expect(v).toContain("camera=()");
+    expect(v).toContain("microphone=()");
+    expect(v).toContain("geolocation=()");
+  });
+
+  describe("Content-Security-Policy", () => {
+    const csp = headerValue("Content-Security-Policy");
+
+    it.each([
+      ["default-src 'self'"],
+      ["frame-ancestors 'none'"],
+      ["object-src 'none'"],
+      ["base-uri 'self'"],
+      ["form-action 'self'"],
+    ])("includes %s", (directive) => {
+      expect(csp).toContain(directive);
+    });
+
+    it("allowlists Plaid for script, frame, connect, and img", () => {
+      expect(csp).toMatch(/script-src[^;]*https:\/\/cdn\.plaid\.com/);
+      expect(csp).toMatch(/frame-src[^;]*https:\/\/cdn\.plaid\.com/);
+      expect(csp).toMatch(/connect-src[^;]*https:\/\/\*\.plaid\.com/);
+      expect(csp).toMatch(/img-src[^;]*https:\/\/\*\.plaid\.com/);
+    });
+
+    it("does not allow 'unsafe-eval'", () => {
+      expect(csp).not.toContain("unsafe-eval");
+    });
+
+    it("does not allowlist origins we no longer use", () => {
+      expect(csp).not.toContain("accounts.google.com");
+      expect(csp).not.toContain("api.telegram.org");
+    });
+  });
+
+  it("nextConfig.headers() applies headers to every path", async () => {
+    const headers = await nextConfig.headers!();
+    expect(headers).toHaveLength(1);
+    expect(headers[0].source).toBe("/:path*");
+    expect(headers[0].headers).toEqual(securityHeaders);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the six baseline HTTP security headers via `next.config.ts` `headers()`:

- `Strict-Transport-Security: max-age=63072000; includeSubDomains`
- `X-Content-Type-Options: nosniff`
- `X-Frame-Options: DENY`
- `Referrer-Policy: strict-origin-when-cross-origin`
- `Permissions-Policy: camera=(), microphone=(), geolocation=()`
- `Content-Security-Policy` (see below)

### CSP directives

```
default-src 'self';
script-src 'self' 'unsafe-inline' https://cdn.plaid.com;
connect-src 'self' https://*.plaid.com;
frame-src https://cdn.plaid.com;
img-src 'self' data: https://*.plaid.com;
style-src 'self' 'unsafe-inline';
font-src 'self' data:;
base-uri 'self';
form-action 'self';
frame-ancestors 'none';
object-src 'none';
```

### Decisions (from challenge round)

| Decision | Why |
|---|---|
| `'unsafe-inline'` in script-src | Next.js hydration scripts; nonce-based deferred to a follow-up |
| Trimmed `accounts.google.com` | NextAuth Google OAuth is a top-level redirect — no client script, no iframe |
| Trimmed `api.telegram.org` | Telegram API is server-side only (`src/lib/telegram.ts`) |
| Drop HSTS `preload` | Keep the option reversible — submit to hstspreload.org later if desired |
| Add `object-src 'none'` | Closes plugin-based XSS vectors; zero behavioral risk |
| Enforce immediately (no report-only) | Solo app — smoke-test on preview, edit config if violations surface |

### Tests

- 15 new unit tests in `src/__tests__/security-headers.test.ts`
- Full suite: 173/173 green
- `npm run build` succeeds

## Test plan

- [ ] `curl -I https://<preview>/` shows all six headers
- [ ] Plaid Link flow works end-to-end on preview
- [ ] Google OAuth flow works end-to-end on preview
- [ ] No console CSP violations during sign-in, dashboard, Plaid link, CSV import
- [ ] securityheaders.com grade ≥ A

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)