### PR TITLE
fix(security): MFA-disable rate limit, timing-safe cron secret, redact PII logs (#106 #107 #77 #69)

### DIFF
--- a/src/__tests__/mfa-disable-route.test.ts
+++ b/src/__tests__/mfa-disable-route.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/db", () => ({ db: {} }));
+
+vi.mock("@/lib/auth", () => ({
+  auth: vi.fn(),
+}));
+
+vi.mock("@/lib/mfa", () => ({
+  disableMfa: vi.fn(),
+  verifyMfaCode: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  audit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/rate-limit", () => ({
+  checkRateLimit: vi.fn(),
+  recordFailure: vi.fn(),
+  resetAttempts: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { auth } from "@/lib/auth";
+import { disableMfa, verifyMfaCode } from "@/lib/mfa";
+import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
+import { POST } from "@/app/api/mfa/disable/route";
+
+const mockedAuth = vi.mocked(auth);
+const mockedDisable = vi.mocked(disableMfa);
+const mockedVerify = vi.mocked(verifyMfaCode);
+const mockedCheckRateLimit = vi.mocked(checkRateLimit);
+const mockedRecordFailure = vi.mocked(recordFailure);
+const mockedResetAttempts = vi.mocked(resetAttempts);
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("https://example.com/api/mfa/disable", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedAuth.mockResolvedValue({
+    user: { id: "u1", email: "a@b.c" },
+    expires: "9999-12-31",
+  } as never);
+  mockedCheckRateLimit.mockResolvedValue({ allowed: true, remaining: 5 });
+});
+
+describe("POST /api/mfa/disable — rate limits MFA code attempts", () => {
+  it("returns 429 and does NOT verify or disable when rate limited", async () => {
+    mockedCheckRateLimit.mockResolvedValueOnce({
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: 60_000,
+    });
+
+    const res = await POST(makeRequest({ code: "123456" }));
+
+    expect(res.status).toBe(429);
+    expect(mockedVerify).not.toHaveBeenCalled();
+    expect(mockedDisable).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 and records a failure on an invalid code", async () => {
+    mockedVerify.mockResolvedValueOnce(false);
+    mockedRecordFailure.mockResolvedValueOnce({ remaining: 4 });
+
+    const res = await POST(makeRequest({ code: "wrongcode" }));
+
+    expect(res.status).toBe(400);
+    expect(mockedRecordFailure).toHaveBeenCalledTimes(1);
+    expect(mockedDisable).not.toHaveBeenCalled();
+  });
+
+  it("disables MFA and resets attempts on a valid code", async () => {
+    mockedVerify.mockResolvedValueOnce(true);
+
+    const res = await POST(makeRequest({ code: "123456" }));
+
+    expect(res.status).toBe(200);
+    expect(mockedDisable).toHaveBeenCalledWith("u1");
+    expect(mockedResetAttempts).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/telegram.test.ts
+++ b/src/__tests__/telegram.test.ts
@@ -56,6 +56,7 @@ describe("sendTelegramMessage", () => {
       "fetch",
       vi.fn().mockResolvedValue({
         ok: false,
+        status: 400,
         text: () => Promise.resolve("Bad Request"),
       })
     );

--- a/src/app/api/cron/cleanup-rate-limits/route.ts
+++ b/src/app/api/cron/cleanup-rate-limits/route.ts
@@ -2,15 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/db";
 import { rateLimitAttempts } from "@/db/schema";
 import { lt } from "drizzle-orm";
-import { withErrorHandling } from "@/lib/api-helpers";
-import { timingSafeCompare } from "@/lib/validation";
+import { requireCronAuth, withErrorHandling } from "@/lib/api-helpers";
 
 async function _GET(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  const expected = `Bearer ${process.env.CRON_SECRET}`;
-  if (!authHeader || !timingSafeCompare(authHeader, expected)) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   const cutoff = new Date(Date.now() - 60 * 60 * 1000); // 1 hour ago
   const deleted = await db

--- a/src/app/api/cron/send-alerts/route.ts
+++ b/src/app/api/cron/send-alerts/route.ts
@@ -1,14 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
 import { sendDailyAlerts, sendWeeklyAlerts } from "@/lib/alerts";
-import { withErrorHandling } from "@/lib/api-helpers";
+import { requireCronAuth, withErrorHandling } from "@/lib/api-helpers";
 
 export const maxDuration = 60;
 
 async function _GET(request: NextRequest) {
-  const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   const type = request.nextUrl.searchParams.get("type") || "daily";
 

--- a/src/app/api/cron/sync-transactions/route.ts
+++ b/src/app/api/cron/sync-transactions/route.ts
@@ -3,16 +3,13 @@ import { db } from "@/db";
 import { accounts } from "@/db/schema";
 import { syncPlaidTransactions } from "@/lib/sync-plaid";
 import { audit } from "@/lib/audit";
-import { withErrorHandling } from "@/lib/api-helpers";
+import { requireCronAuth, withErrorHandling } from "@/lib/api-helpers";
 
 export const maxDuration = 300; // 5 minutes for Vercel
 
 async function _GET(request: NextRequest) {
-  // Verify cron secret
-  const authHeader = request.headers.get("authorization");
-  if (authHeader !== `Bearer ${process.env.CRON_SECRET}`) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+  const denied = requireCronAuth(request);
+  if (denied) return denied;
 
   const allAccounts = await db.select().from(accounts);
   const result = await syncPlaidTransactions(allAccounts);

--- a/src/app/api/mfa/disable/route.ts
+++ b/src/app/api/mfa/disable/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireUser, withErrorHandling } from "@/lib/api-helpers";
 import { disableMfa, verifyMfaCode } from "@/lib/mfa";
 import { audit } from "@/lib/audit";
+import { checkRateLimit, recordFailure, resetAttempts } from "@/lib/rate-limit";
 
 async function _POST(request: NextRequest) {
   const guard = await requireUser();
@@ -15,12 +16,42 @@ async function _POST(request: NextRequest) {
     return NextResponse.json({ error: "MFA code required" }, { status: 400 });
   }
 
+  // Rate-limit MFA code attempts (shared bucket with verify) so a stolen
+  // session can't brute-force the 6-digit code to disable MFA.
+  const rateLimitKey = `mfa:${session.user.id}`;
+  const limit = await checkRateLimit(rateLimitKey);
+  if (!limit.allowed) {
+    await audit({
+      userId: session.user.id,
+      action: "auth.mfa_rate_limited",
+      resource: "mfa",
+      detail: { retryAfterMs: limit.retryAfterMs },
+      request,
+    });
+    return NextResponse.json(
+      { error: "Too many attempts. Try again later." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(Math.ceil(limit.retryAfterMs! / 1000)) },
+      },
+    );
+  }
+
   // Require current MFA code to disable
   const valid = await verifyMfaCode(session.user.id, code);
   if (!valid) {
+    const { remaining } = await recordFailure(rateLimitKey);
+    await audit({
+      userId: session.user.id,
+      action: "auth.mfa_failed",
+      resource: "mfa",
+      detail: { phase: "disable", attemptsRemaining: remaining },
+      request,
+    });
     return NextResponse.json({ error: "Invalid code" }, { status: 400 });
   }
 
+  await resetAttempts(rateLimitKey);
   await disableMfa(session.user.id);
 
   await audit({

--- a/src/lib/api-helpers.ts
+++ b/src/lib/api-helpers.ts
@@ -1,7 +1,8 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import type { Session } from "next-auth";
 import { auth } from "./auth";
 import { getUserRole, hasMinRole, type UserRole } from "./rbac";
+import { timingSafeCompare } from "./validation";
 
 export type AuthGuard = { userId: string; session: Session };
 export type RoleGuard = AuthGuard & { role: UserRole };
@@ -28,6 +29,19 @@ export async function requireRole(
 
 export async function requireAdmin(): Promise<RoleGuard | NextResponse> {
   return requireRole("admin");
+}
+
+/**
+ * Verify a cron route's Bearer secret in constant time. Returns a 401
+ * NextResponse to return on failure, or null when the request is authorized.
+ */
+export function requireCronAuth(request: NextRequest): NextResponse | null {
+  const authHeader = request.headers.get("authorization");
+  const expected = `Bearer ${process.env.CRON_SECRET}`;
+  if (!authHeader || !timingSafeCompare(authHeader, expected)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+  return null;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/lib/sync-plaid.ts
+++ b/src/lib/sync-plaid.ts
@@ -162,8 +162,13 @@ export async function syncPlaidTransactions(
         .set({ cursor })
         .where(inArray(accounts.id, itemAccountIds));
     } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`Sync failed for item ${itemId}:`, message);
+      const isError = err instanceof Error;
+      const message = isError ? err.message : String(err);
+      // Log the error class only — Plaid messages can carry PII; the full
+      // message stays in the structured result returned to the cron caller.
+      console.error(
+        `Sync failed for item ${itemId} (${isError ? err.name : "unknown error"})`,
+      );
       errors.push({ itemId, error: message });
     }
   }

--- a/src/lib/telegram.ts
+++ b/src/lib/telegram.ts
@@ -25,8 +25,8 @@ export async function sendTelegramMessage(
   });
 
   if (!response.ok) {
-    const error = await response.text();
-    console.error("Telegram send failed:", error);
+    // Log status only — the response body can echo message/chat content (PII).
+    console.error(`Telegram send failed: HTTP ${response.status}`);
     return false;
   }
   return true;


### PR DESCRIPTION
First-batch security hardening (auth / secrets / data-exposure). Issues were triaged against **current** code first — several "open" issues are already fixed in `main` (see triage note), so this PR only touches genuinely-open ones.

## Closes #106 — MFA disable endpoint had no rate limiting
`/api/mfa/disable` called `verifyMfaCode` directly with no rate limit, so a stolen session could brute-force the 6-digit TOTP to turn MFA off. Adds the same `checkRateLimit` / `recordFailure` / `resetAttempts` guard the verify route uses, sharing the `mfa:<userId>` bucket so the limit can't be bypassed by alternating endpoints. Returns 429 + `Retry-After` on lockout; audits rate-limit and failure events.

## Closes #107, Closes #77 — non-timing-safe CRON_SECRET comparison
`sync-transactions` (the Plaid bank-data sync) and `send-alerts` compared the Bearer secret with a timing-leaky `!==`. Introduces a shared `requireCronAuth(request)` guard in `api-helpers.ts` (constant-time via the existing `timingSafeCompare`) and routes all three cron endpoints through it — consolidating the (now-triplicated) inline check into one audited guard.

## Closes #69 — PII in Plaid sync / Telegram error logs
`sync-plaid` logged full `err.message` and `telegram` logged the full response body — both can carry PII (institution names, account masks, chat content). Now log the error class / HTTP status only; the full Plaid message stays in the structured result returned to the authenticated cron caller.

## Triage note — stale issues (recommend closing, NOT in this PR)
- **#66** — `allowDangerousEmailAccountLinking` has zero occurrences in `src/` (already removed).
- **#68** — the `middleware.ts:19-20` bypass it cites was refactored away (middleware now uses `evaluateGate`); its residual concern is the defense-in-depth matcher item #111.

## Tests / build
- New `mfa-disable-route` tests (rate-limit blocks before verify; failure records; success disables + resets).
- `vitest`: **176 passed**. `eslint`: clean. `tsc --noEmit`: clean for changed files (3 pre-existing errors in `profile-email-change.test.ts` are unrelated and do not block `next build`). `next build`: succeeds.
- `/simplify` run: extracted the shared `requireCronAuth` guard + a sync-plaid log cleanup; efficiency / altitude otherwise clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
